### PR TITLE
Core chase triggers remain inactive

### DIFF
--- a/ExistentialRules/ChaseSequence/ChaseBranch.lean
+++ b/ExistentialRules/ChaseSequence/ChaseBranch.lean
@@ -56,6 +56,13 @@ theorem func_term_not_mem_head {cb : ChaseBranch N obs kb} {t : GroundTerm sig} 
   rw [t_eq'] at t_eq
   simp [GroundTerm.func_neq_const] at t_eq
 
+/-- A node that has an origin must be in the tail. -/
+theorem mem_tail_of_isSome_origin {cb : ChaseBranch N obs kb} {n : N} (n_mem : n ∈ cb.toChaseDerivation) : (CN.origin n).isSome -> ∃ next_some, n ∈ cb.tail next_some := by
+  intro isSome_origin
+  cases cb.mem_iff_eq_head_or_mem_tail.mp n_mem with
+  | inl mem => exfalso; rw [Option.isSome_iff_ne_none] at isSome_origin; apply isSome_origin; rw [mem]; exact cb.database_first'.right.right
+  | inr mem => exact mem
+
 end ChaseBranch
 
 /-!

--- a/ExistentialRules/ChaseSequence/ChaseDerivation.lean
+++ b/ExistentialRules/ChaseSequence/ChaseDerivation.lean
@@ -234,7 +234,8 @@ theorem next_mem_tail {cd : ChaseDerivation N obs rules} {next_some : cd.next.is
   ChaseDerivationSkeleton.next_mem_tail
 
 /-- A node is a member if and only if it is either the head or it is a member of the tail. -/
-theorem mem_iff_eq_head_or_mem_tail {cd : ChaseDerivation N obs rules} {node : N} : node ∈ cd ↔ node = cd.head ∨ ∃ h, node ∈ cd.tail h :=
+theorem mem_iff_eq_head_or_mem_tail {cd : ChaseDerivation N obs rules} {node : N} :
+    node ∈ cd ↔ node = cd.head ∨ ∃ h, node ∈ cd.tail h :=
   ChaseDerivationSkeleton.mem_iff_eq_head_or_mem_tail
 
 /-- A derivation is a suffix of another if and only if both are the same or the first is a suffix of the second's tail. -/
@@ -326,125 +327,135 @@ variable {N : Type u} [CN : ChaseNode N obs rules]
 theorem constants_node_subset_constants_fs_union_constants_rules
     (out_sub_in : CN.out_sub_in)
     {cd : ChaseDerivation N obs rules}
-    (start_eq : CN.ingoingFacts cd.head = CN.outgoingFacts cd.head)
-    {node : N} (node_mem : node ∈ cd) :
+    {next_some : cd.next.isSome}
+    {node : N} (node_mem : node ∈ cd.tail next_some) :
     (CN.ingoingFacts node).constants ⊆ ((CN.outgoingFacts cd.head).constants ∪ rules.head_constants) := by
-  let node' : cd.Node := ⟨node, node_mem⟩
+  let node' : (cd.tail next_some).Node := ⟨node, node_mem⟩
   show (CN.ingoingFacts node'.val).constants ⊆ ((CN.outgoingFacts cd.head).constants ∪ rules.head_constants)
-  induction node' using mem_rec with
-  | head =>
-    apply Set.subset_union_of_subset_left
-    rw [start_eq]
-    apply Set.subset_refl
-  | step cd2 suffix ih next next_eq =>
-    rw [ChaseDerivationSkeleton.facts_next next_eq]
-    intro c c_mem
-    rw [FactSet.constants_union] at c_mem
-    cases c_mem with
-    | inl c_mem => apply ih; apply FactSet.constants_subset_of_subset out_sub_in; exact c_mem
-    | inr c_mem =>
-      let origin := (CN.origin next).get (cd2.isSome_origin_next next_eq)
-      apply Set.subset_trans (origin.fst.val.mapped_head_constants_subset origin.snd)
-      . intro c c_mem
-        rw [List.mem_toSet, List.mem_append] at c_mem
-        cases c_mem with
-        | inl c_mem =>
-          apply ih
-          rw [List.mem_flatMap] at c_mem
-          rcases c_mem with ⟨t, t_mem, c_mem⟩
-          rw [List.mem_map] at t_mem
-          rcases t_mem with ⟨v, v_mem, t_mem⟩
-          rcases FunctionFreeConjunction.mem_vars.mp (origin.fst.val.rule.frontier_subset_vars_body v_mem) with ⟨a, a_mem, v_mem'⟩
-          exists origin.fst.val.subs.apply_function_free_atom a
+
+  suffices ∀ cd2 : ChaseDerivation N obs rules, ∀ next ∈ cd2.next, (CN.ingoingFacts next).constants ⊆ ((CN.outgoingFacts cd2.head).constants ∪ rules.head_constants) by
+    induction node' using mem_rec with
+    | head => simp only [cd.head_tail']; apply this; simp
+    | step cd2 suffix ih next next_eq =>
+      specialize this cd2 next next_eq
+      apply Set.subset_trans this
+      rw [Set.union_subset_iff_both_subset]; constructor
+      . apply Set.subset_trans _ ih; exact FactSet.constants_subset_of_subset out_sub_in
+      . apply Set.subset_union_of_subset_right; exact Set.subset_refl
+
+  intro cd2 next next_mem
+  rw [ChaseDerivationSkeleton.facts_next next_mem]
+  intro c c_mem
+  rw [FactSet.constants_union] at c_mem
+  cases c_mem with
+  | inl c_mem => apply Or.inl; exact c_mem
+  | inr c_mem =>
+    let origin := (CN.origin next).get (cd2.isSome_origin_next next_mem)
+    apply Set.subset_trans (origin.fst.val.mapped_head_constants_subset origin.snd)
+    . intro c c_mem
+      rw [List.mem_toSet, List.mem_append] at c_mem
+      cases c_mem with
+      | inl c_mem =>
+        apply Or.inl
+        rw [List.mem_flatMap] at c_mem
+        rcases c_mem with ⟨t, t_mem, c_mem⟩
+        rw [List.mem_map] at t_mem
+        rcases t_mem with ⟨v, v_mem, t_mem⟩
+        rcases FunctionFreeConjunction.mem_vars.mp (origin.fst.val.rule.frontier_subset_vars_body v_mem) with ⟨a, a_mem, v_mem'⟩
+        exists origin.fst.val.subs.apply_function_free_atom a
+        constructor
+        . apply (cd2.active_trigger_origin_next next_mem).left
+          rw [List.mem_toSet]
+          apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_list
+          exact a_mem
+        . unfold Fact.constants
+          rw [List.mem_flatMap]
+          exists t
           constructor
-          . apply out_sub_in
-            apply (cd2.active_trigger_origin_next next_eq).left
-            rw [List.mem_toSet]
-            apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_list
-            exact a_mem
-          . unfold Fact.constants
-            rw [List.mem_flatMap]
-            exists t
+          . unfold GroundSubstitution.apply_function_free_atom
+            unfold TermMapping.apply_generalized_atom
+            rw [List.mem_map]
+            exists VarOrConst.var v
             constructor
-            . unfold GroundSubstitution.apply_function_free_atom
-              unfold TermMapping.apply_generalized_atom
-              rw [List.mem_map]
-              exists VarOrConst.var v
-              constructor
-              . exact v_mem'
-              . unfold PreTrigger.subs_for_mapped_head at t_mem
-                rw [PreTrigger.apply_to_var_or_const_frontier_var _ _ _ v_mem] at t_mem
-                exact t_mem
-            . exact c_mem
-        | inr c_mem =>
-          apply Or.inr
-          exists origin.fst.val.rule
-          constructor
-          . exact origin.fst.property
-          . unfold Rule.head_constants
-            grind
-      . exact c_mem
+            . exact v_mem'
+            . unfold PreTrigger.subs_for_mapped_head at t_mem
+              rw [PreTrigger.apply_to_var_or_const_frontier_var _ _ _ v_mem] at t_mem
+              exact t_mem
+          . exact c_mem
+      | inr c_mem =>
+        apply Or.inr
+        exists origin.fst.val.rule
+        constructor
+        . exact origin.fst.property
+        . unfold Rule.head_constants
+          grind
+    . exact c_mem
 
 /-- Each functional term in the chase originates as a fresh term from a trigger if it was not already part of the initial fact set. -/
 theorem functional_term_originates_from_some_trigger
     (out_sub_in : CN.out_sub_in)
     {cd : ChaseDerivation N obs rules}
-    (start_eq : CN.ingoingFacts cd.head = CN.outgoingFacts cd.head)
-    (predecessor_trans : ∀ {n1 n2 n3 : cd.Node}, n1 ≼ n2 -> n2 ≼ n3 -> n1 ≼ n3)
-    (node : Node cd)
+    {next_some : cd.next.isSome}
+    (predecessor_trans : ∀ {n1 n2 n3 : (cd.tail next_some).Node}, n1 ≼ n2 -> n2 ≼ n3 -> n1 ≼ n3)
+    (node : (cd.tail next_some).Node)
     {t : GroundTerm sig}
     (t_is_func : ∃ func ts arity_ok, t = GroundTerm.func func ts arity_ok)
     (t_mem : t ∈ (CN.ingoingFacts node.val).terms) :
     t ∈ (CN.outgoingFacts cd.head).terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ (CN.origin node2.val), t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
-  induction node using mem_rec with
-  | head => apply Or.inl; rw [← start_eq]; exact t_mem
-  | step cd2 suffix ih next next_mem =>
-    rw [cd2.facts_next next_mem, FactSet.terms_union] at t_mem
-
-    have aux : t ∈ (CN.ingoingFacts cd2.head).terms -> t ∈ (CN.outgoingFacts cd.head).terms ∨ ∃ (node2 : cd.Node), node2 ≼ ⟨next, cd2.mem_of_mem_suffix suffix _ (cd2.next_mem_of_mem _ next_mem)⟩ ∧ ∃ orig ∈ (CN.origin node2.val), t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
-      intro t_mem
-      cases ih t_mem with
-      | inl ih => apply Or.inl; exact ih
-      | inr ih =>
-        rcases ih with ⟨node2, prec, t_mem⟩
-        apply Or.inr; exists node2; constructor;
-        . apply predecessor_trans prec
-          exact ChaseDerivationSkeleton.predecessor_of_suffix suffix (ChaseDerivationSkeleton.head_prec_next next_mem)
-        . exact t_mem
-
-    cases t_mem with
-    | inl t_mem => exact aux (FactSet.terms_subset_of_subset out_sub_in _ t_mem)
-    | inr t_mem =>
-      unfold ChaseNode.origin_result at t_mem
-      rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_head_iff] at t_mem
-      cases t_mem with
-      | inl t_mem => rcases t_is_func with ⟨func, ts, arity, t_is_func⟩; rcases t_mem with ⟨c, _, t_mem⟩; rw [← t_mem] at t_is_func; apply False.elim; exact GroundTerm.func_neq_const (Eq.symm t_is_func)
-      | inr t_mem =>
-      cases t_mem with
-      | inr t_mem =>
-        apply Or.inr; exists ⟨next, cd2.mem_of_mem_suffix suffix _ (cd2.next_mem_of_mem _ next_mem)⟩; constructor
-        . exact ChaseDerivationSkeleton.predecessor_refl
-        . exists (CN.origin next).get (cd2.isSome_origin_next next_mem)
-          simp only [Option.get_mem, true_and]
-          exact t_mem
+  suffices ∀ cd2 : ChaseDerivation N obs rules, ∀ next ∈ cd2.next, t ∈ (CN.ingoingFacts next).terms -> t ∈ ((CN.outgoingFacts cd2.head).terms) ∨ ∃ orig ∈ (CN.origin next), t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) by
+    induction node using mem_rec with
+    | head =>
+      simp only [cd.head_tail']
+      simp only [cd.head_tail'] at t_mem
+      cases this cd (cd.next.get next_some) (by simp) t_mem with
+      | inl t_mem => apply Or.inl; exact t_mem
+      | inr t_mem => apply Or.inr; exists ⟨cd.next.get next_some, by grind⟩; constructor; exact ChaseDerivationSkeleton.predecessor_refl; exact t_mem
+    | step cd2 suffix ih next next_mem =>
+      cases this _ _ next_mem t_mem with
       | inl t_mem =>
-        apply aux
-        apply FactSet.terms_subset_of_subset out_sub_in
-        apply FactSet.terms_subset_of_subset (cd2.active_trigger_origin_next next_mem).left
-        rw [List.mem_map] at t_mem
-        rcases t_mem with ⟨v, v_mem, t_mem⟩
-        rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
-        apply Or.inr
-        exists v; simp only [t_mem, and_true]
-        apply Rule.frontier_subset_vars_body; rw [Rule.mem_frontier_iff_mem_frontier_for_head]; exact ⟨_, ⟨_, v_mem⟩⟩
+        cases ih (FactSet.terms_subset_of_subset out_sub_in _ t_mem) with
+        | inl ih => apply Or.inl; exact ih
+        | inr ih =>
+          rcases ih with ⟨node2, prec, t_mem⟩
+          apply Or.inr; exists node2; constructor;
+          . apply predecessor_trans prec
+            exact ChaseDerivationSkeleton.predecessor_of_suffix suffix (ChaseDerivationSkeleton.head_prec_next next_mem)
+          . exact t_mem
+      | inr t_mem => apply Or.inr; exact ⟨_, ChaseDerivationSkeleton.predecessor_refl, t_mem⟩
+
+  intro cd2 next next_mem t_mem
+  rw [cd2.facts_next next_mem, FactSet.terms_union] at t_mem
+  cases t_mem with
+  | inl t_mem => apply Or.inl; exact t_mem
+  | inr t_mem =>
+    unfold ChaseNode.origin_result at t_mem
+    rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_head_iff] at t_mem
+    cases t_mem with
+    | inl t_mem => rcases t_is_func with ⟨func, ts, arity, t_is_func⟩; rcases t_mem with ⟨c, _, t_mem⟩; rw [← t_mem] at t_is_func; apply False.elim; exact GroundTerm.func_neq_const (Eq.symm t_is_func)
+    | inr t_mem =>
+    cases t_mem with
+    | inr t_mem =>
+      apply Or.inr
+      exists (CN.origin next).get (cd2.isSome_origin_next next_mem)
+      simp only [Option.get_mem, true_and]
+      exact t_mem
+    | inl t_mem =>
+      apply Or.inl
+      apply FactSet.terms_subset_of_subset (cd2.active_trigger_origin_next next_mem).left
+      rw [List.mem_map] at t_mem
+      rcases t_mem with ⟨v, v_mem, t_mem⟩
+      rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
+      apply Or.inr
+      exists v; simp only [t_mem, and_true]
+      apply Rule.frontier_subset_vars_body; rw [Rule.mem_frontier_iff_mem_frontier_for_head]; exact ⟨_, ⟨_, v_mem⟩⟩
 
 /-- If a functional term occurs in the chase, then the trigger that introduces this term must have been used in the chase, unless the term already occurs in the initial fact set. -/
 theorem trigger_introducing_functional_term_occurs_in_chase
     (out_sub_in : CN.out_sub_in)
     {cd : ChaseDerivation N obs rules}
-    (start_eq : CN.ingoingFacts cd.head = CN.outgoingFacts cd.head)
-    (predecessor_trans : ∀ {n1 n2 n3 : cd.Node}, n1 ≼ n2 -> n2 ≼ n3 -> n1 ≼ n3)
-    (node : Node cd)
+    {next_some : cd.next.isSome}
+    (predecessor_trans : ∀ {n1 n2 n3 : (cd.tail next_some).Node}, n1 ≼ n2 -> n2 ≼ n3 -> n1 ≼ n3)
+    (node : (cd.tail next_some).Node)
     {t : GroundTerm sig}
     (t_mem_node : t ∈ (CN.ingoingFacts node.val).terms)
     {trg : RTrigger obs rules}
@@ -452,7 +463,7 @@ theorem trigger_introducing_functional_term_occurs_in_chase
     {lt : disj_idx < trg.val.rule.head.length}
     (t_mem_trg : t ∈ trg.val.fresh_terms_for_head_disjunct disj_idx lt) :
     t ∈ (CN.outgoingFacts cd.head).terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ (CN.origin node2.val), orig.fst.equiv trg ∧ orig.snd.val = disj_idx := by
-  cases functional_term_originates_from_some_trigger out_sub_in start_eq predecessor_trans node (by
+  cases functional_term_originates_from_some_trigger out_sub_in predecessor_trans node (by
     cases eq : t with
     | const _ =>
       rw [eq] at t_mem_trg
@@ -747,8 +758,11 @@ theorem constants_node_subset_constants_fs_union_constants_rules
     {cd : RegularChaseDerivation obs rules}
     {node : RegularChaseNode obs rules} (node_mem : node ∈ cd) :
     node.facts.constants ⊆ cd.head.facts.constants ∪ rules.head_constants := by
-  apply ChaseDerivation.constants_node_subset_constants_fs_union_constants_rules RegularChaseNode.out_sub_in _ node_mem
-  rw [RegularChaseNode.ingoingFacts_eq, RegularChaseNode.outgoingFacts_eq]
+  cases cd.mem_iff_eq_head_or_mem_tail.mp node_mem with
+  | inl node_mem => apply Set.subset_union_of_subset_left; rw [node_mem]; exact Set.subset_refl
+  | inr node_mem =>
+    rcases node_mem with ⟨_, node_mem⟩
+    exact ChaseDerivation.constants_node_subset_constants_fs_union_constants_rules RegularChaseNode.out_sub_in node_mem
 
 /-- Each functional term in the chase originates as a fresh term from a trigger if it was not already part of the initial fact set. -/
 theorem functional_term_originates_from_some_trigger
@@ -758,8 +772,17 @@ theorem functional_term_originates_from_some_trigger
     (t_is_func : ∃ func ts arity_ok, t = GroundTerm.func func ts arity_ok)
     (t_mem : t ∈ node.val.facts.terms) :
     t ∈ cd.head.facts.terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.val.origin, t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
-  apply ChaseDerivation.functional_term_originates_from_some_trigger RegularChaseNode.out_sub_in _ predecessor_trans node t_is_func t_mem
-  rw [RegularChaseNode.ingoingFacts_eq, RegularChaseNode.outgoingFacts_eq]
+  cases cd.mem_iff_eq_head_or_mem_tail.mp node.property with
+  | inl node_mem => apply Or.inl; rw [← node_mem]; exact t_mem
+  | inr node_mem =>
+    rcases node_mem with ⟨next_some, node_mem⟩
+    rw [← cd.head.outgoingFacts_eq]
+    cases ChaseDerivation.functional_term_originates_from_some_trigger RegularChaseNode.out_sub_in predecessor_trans ⟨node.val, node_mem⟩ t_is_func (by rw [node.val.ingoingFacts_eq]; exact t_mem) with
+    | inl t_mem => apply Or.inl; exact t_mem
+    | inr t_mem =>
+      apply Or.inr; rcases t_mem with ⟨node2, prec, t_mem⟩
+      have suf : cd.tail next_some <:+ cd := PossiblyInfiniteList.IsSuffix_tail
+      exact ⟨_, ChaseDerivationSkeleton.predecessor_of_suffix suf prec, t_mem⟩
 
 /-- If a functional term occurs in the chase, then the trigger that introduces this term must have been used in the chase, unless the term already occurs in the initial fact set. -/
 theorem trigger_introducing_functional_term_occurs_in_chase
@@ -772,8 +795,17 @@ theorem trigger_introducing_functional_term_occurs_in_chase
     {lt : disj_idx < trg.val.rule.head.length}
     (t_mem_trg : t ∈ trg.val.fresh_terms_for_head_disjunct disj_idx lt) :
     t ∈ cd.head.facts.terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.val.origin, orig.fst.equiv trg ∧ orig.snd.val = disj_idx := by
-  apply ChaseDerivation.trigger_introducing_functional_term_occurs_in_chase RegularChaseNode.out_sub_in _ predecessor_trans node t_mem_node t_mem_trg
-  rw [RegularChaseNode.ingoingFacts_eq, RegularChaseNode.outgoingFacts_eq]
+  cases cd.mem_iff_eq_head_or_mem_tail.mp node.property with
+  | inl node_mem => apply Or.inl; rw [← node_mem]; exact t_mem_node
+  | inr node_mem =>
+    rcases node_mem with ⟨next_some, node_mem⟩
+    rw [← cd.head.outgoingFacts_eq]
+    cases ChaseDerivation.trigger_introducing_functional_term_occurs_in_chase RegularChaseNode.out_sub_in predecessor_trans ⟨node.val, node_mem⟩ t_mem_node t_mem_trg with
+    | inl t_mem => apply Or.inl; exact t_mem
+    | inr t_mem =>
+      apply Or.inr; rcases t_mem with ⟨node2, prec, t_mem⟩
+      have suf : cd.tail next_some <:+ cd := PossiblyInfiniteList.IsSuffix_tail
+      exact ⟨_, ChaseDerivationSkeleton.predecessor_of_suffix suf prec, t_mem⟩
 
 /-- If a functional term occurs in the chase, then the result of the trigger that introduces this term is contained in the current node, unless the functional term already occurs in the initial fact set. -/
 theorem result_of_trigger_introducing_functional_term_occurs_in_chase

--- a/ExistentialRules/ChaseSequence/ChaseDerivation.lean
+++ b/ExistentialRules/ChaseSequence/ChaseDerivation.lean
@@ -601,6 +601,24 @@ theorem strict_predecessor_trans {cd : RegularChaseDerivation obs rules} {n1 n2 
   . exact predecessor_trans prec1.left prec2.left
   . grind
 
+/-- The strict predecessor relation is transitive with respect to the regular predecessor relation. -/
+@[grind ->]
+theorem strict_prec_of_prec_of_strict_prec {cd : RegularChaseDerivation obs rules} {n1 n2 n3 : cd.Node} :
+    n1 ≼ n2 -> n2 ≺ n3 -> n1 ≺ n3 := by
+  intro prec1 prec2
+  constructor
+  . exact predecessor_trans prec1 prec2.left
+  . cases cd.eq_or_strict_of_predecessor prec1 <;> grind
+
+/-- The strict predecessor relation is transitive with respect to the regular predecessor relation. -/
+@[grind ->]
+theorem strict_prec_of_strict_prec_of_prec {cd : RegularChaseDerivation obs rules} {n1 n2 n3 : cd.Node} :
+    n1 ≺ n2 -> n2 ≼ n3 -> n1 ≺ n3 := by
+  intro prec1 prec2
+  constructor
+  . exact predecessor_trans prec1.left prec2
+  . cases cd.eq_or_strict_of_predecessor prec2 <;> grind
+
 /-- The `ChaseDerivationSkeleton.head` is a strict predecessor of `ChaseDerivationSkeleton.next`. -/
 theorem head_strict_prec_next {cd : RegularChaseDerivation obs rules} :
     ∀ {next}, (mem : next ∈ cd.next) -> ⟨cd.head, cd.head_mem⟩ ≺ ⟨next, cd.next_mem_of_mem _ mem⟩ := by

--- a/ExistentialRules/ChaseSequence/CoreChase/CoreChaseBranch.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/CoreChaseBranch.lean
@@ -263,30 +263,30 @@ that the trigger that introduces this term must have been applied in some `Chase
 /-- Constants in the chase can only come from the initial fact set or from a constant in a rule. -/
 theorem constants_node_subset_constants_fs_union_constants_rules
     {cd : CoreChaseDerivation rules}
-    (start_eq : cd.head.facts = cd.head.core)
-    {node : CoreChaseNode rules} (node_mem : node ∈ cd) :
-    node.facts.constants ⊆ cd.head.core.constants ∪ rules.head_constants := by
-  exact ChaseDerivation.constants_node_subset_constants_fs_union_constants_rules CoreChaseNode.out_sub_in start_eq node_mem
+    {next_some : cd.next.isSome}
+    {node : CoreChaseNode rules} (node_mem : node ∈ cd.tail next_some) :
+    node.facts.constants ⊆ cd.head.core.constants ∪ rules.head_constants :=
+  ChaseDerivation.constants_node_subset_constants_fs_union_constants_rules CoreChaseNode.out_sub_in node_mem
 
 /-- Each functional term in the chase originates as a fresh term from a trigger if it was not already part of the initial fact set. -/
 theorem functional_term_originates_from_some_trigger
     {cd : CoreChaseDerivation rules}
-    (start_eq : cd.head.facts = cd.head.core)
+    {next_some : cd.next.isSome}
     (start_finite : cd.head.core.finite)
-    (node : cd.Node)
+    (node : (cd.tail next_some).Node)
     {t : GroundTerm sig}
     (t_is_func : ∃ func ts arity_ok, t = GroundTerm.func func ts arity_ok)
     (t_mem : t ∈ node.val.facts.terms) :
     t ∈ cd.head.core.terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.val.origin, t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
-  apply ChaseDerivation.functional_term_originates_from_some_trigger CoreChaseNode.out_sub_in start_eq _ node t_is_func t_mem
-  intro n1 n2 n3; apply predecessor_trans_of_finite; apply cd.core_finite_of_mem_of_head_finite; exact start_finite
+  apply ChaseDerivation.functional_term_originates_from_some_trigger CoreChaseNode.out_sub_in _ node t_is_func t_mem
+  intro n1 n2 n3; apply predecessor_trans_of_finite; apply core_finite_of_mem_of_head_finite; rw [ChaseDerivation.head_tail']; apply cd.core_finite_of_mem_of_head_finite _ ⟨cd.next.get next_some, by apply cd.next_mem_of_mem; simp⟩; exact start_finite
 
 /-- If a functional term occurs in the chase, then the trigger that introduces this term must have been used in the chase, unless the term already occurs in the initial fact set. -/
 theorem trigger_introducing_functional_term_occurs_in_chase
     {cd : CoreChaseDerivation rules}
-    (start_eq : cd.head.facts = cd.head.core)
+    {next_some : cd.next.isSome}
     (start_finite : cd.head.core.finite)
-    (node : cd.Node)
+    (node : (cd.tail next_some).Node)
     {t : GroundTerm sig}
     (t_mem_node : t ∈ node.val.facts.terms)
     {trg : RTrigger (RestrictedObsolescence sig) rules}
@@ -294,8 +294,8 @@ theorem trigger_introducing_functional_term_occurs_in_chase
     {lt : disj_idx < trg.val.rule.head.length}
     (t_mem_trg : t ∈ trg.val.fresh_terms_for_head_disjunct disj_idx lt) :
     t ∈ cd.head.core.terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.val.origin, orig.fst.equiv trg ∧ orig.snd.val = disj_idx := by
-  apply ChaseDerivation.trigger_introducing_functional_term_occurs_in_chase CoreChaseNode.out_sub_in start_eq _ node t_mem_node t_mem_trg
-  intro n1 n2 n3; apply predecessor_trans_of_finite; apply cd.core_finite_of_mem_of_head_finite; exact start_finite
+  apply ChaseDerivation.trigger_introducing_functional_term_occurs_in_chase CoreChaseNode.out_sub_in _ node t_mem_node t_mem_trg
+  intro n1 n2 n3; apply predecessor_trans_of_finite; apply core_finite_of_mem_of_head_finite; rw [ChaseDerivation.head_tail']; apply cd.core_finite_of_mem_of_head_finite _ ⟨cd.next.get next_some, by apply cd.next_mem_of_mem; simp⟩; exact start_finite
 
 end TermsInChase
 
@@ -509,12 +509,12 @@ that the trigger that introduces this term must have been applied in some `Chase
 /-- Constants in the chase must be in the database or in some rule. -/
 theorem constants_node_subset_constants_db_union_constants_rules {cb : CoreChaseBranch kb} {node : cb.Node} :
     node.val.facts.constants ⊆ (kb.db.constants.val ∪ kb.rules.head_constants) := by
-  have start_eq : cb.head.facts = cb.head.core := by
-    rw [← cb.head.outgoingFacts_eq, cb.database_first'.right.left]
-    rw [← cb.head.ingoingFacts_eq, cb.database_first'.left]
-  have := CoreChaseDerivation.constants_node_subset_constants_fs_union_constants_rules start_eq node.property
-  rw [← cb.head.outgoingFacts_eq, cb.database_first'.right.left, Database.toFactSet_constants_same] at this
-  exact this
+  cases ChaseDerivation.mem_iff_eq_head_or_mem_tail.mp node.property with
+  | inl node_mem => apply Set.subset_union_of_subset_left; rw [node_mem, ← cb.head.ingoingFacts_eq, cb.database_first'.left, Database.toFactSet_constants_same]; exact Set.subset_refl
+  | inr node_mem =>
+    rcases node_mem with ⟨_, node_mem⟩
+    rw [← Database.toFactSet_constants_same, ← cb.database_first'.right.left, cb.head.outgoingFacts_eq]
+    exact CoreChaseDerivation.constants_node_subset_constants_fs_union_constants_rules node_mem
 
 /-- Each functional term in the chase originates as a fresh term from a trigger. -/
 theorem functional_term_originates_from_some_trigger
@@ -525,13 +525,22 @@ theorem functional_term_originates_from_some_trigger
     (t_mem : t ∈ node.val.facts.terms) :
     ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.val.origin,
       t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
-  have start_eq : cb.head.facts = cb.head.core := by
-    rw [← cb.head.outgoingFacts_eq, cb.database_first'.right.left]
-    rw [← cb.head.ingoingFacts_eq, cb.database_first'.left]
-  have start_finite := (cb.core_finite_of_mem ⟨_, cb.head_mem⟩)
-  cases CoreChaseDerivation.functional_term_originates_from_some_trigger start_eq start_finite node t_is_func t_mem with
-  | inl t_mem => apply False.elim; exact cb.func_term_not_mem_head t_is_func t_mem
-  | inr t_mem => exact t_mem
+  have t_nmem_head : t ∉ cb.head.core.terms := by
+    intro t_mem
+    exact cb.func_term_not_mem_head t_is_func t_mem
+  cases ChaseDerivation.mem_iff_eq_head_or_mem_tail.mp node.property with
+  | inl node_mem =>
+    rw [node_mem, ← cb.head.ingoingFacts_eq, cb.database_first'.left, ← cb.database_first'.right.left] at t_mem
+    apply False.elim; apply t_nmem_head; exact t_mem
+  | inr node_mem =>
+    have start_finite := (cb.core_finite_of_mem ⟨_, cb.head_mem⟩)
+    rcases node_mem with ⟨next_some, node_mem⟩
+    cases CoreChaseDerivation.functional_term_originates_from_some_trigger start_finite ⟨node.val, node_mem⟩ t_is_func t_mem with
+    | inl t_mem => apply False.elim; exact t_nmem_head t_mem
+    | inr t_mem =>
+      rcases t_mem with ⟨node2, prec, t_mem⟩
+      have suf : (cb.tail next_some) <:+ cb.toChaseDerivation := PossiblyInfiniteList.IsSuffix_tail
+      exact ⟨_, ChaseDerivationSkeleton.predecessor_of_suffix suf prec, t_mem⟩
 
 /-- If a functional term occurs in the chase, then the trigger that introduces this term must have been used in the chase. -/
 theorem trigger_introducing_functional_term_occurs_in_chase
@@ -544,13 +553,22 @@ theorem trigger_introducing_functional_term_occurs_in_chase
     {lt : disj_idx < trg.val.rule.head.length}
     (t_mem_trg : t ∈ trg.val.fresh_terms_for_head_disjunct disj_idx lt) :
     ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.val.origin, orig.fst.equiv trg ∧ orig.snd.val = disj_idx := by
-  have start_eq : cb.head.facts = cb.head.core := by
-    rw [← cb.head.outgoingFacts_eq, cb.database_first'.right.left]
-    rw [← cb.head.ingoingFacts_eq, cb.database_first'.left]
-  have start_finite := (cb.core_finite_of_mem ⟨_, cb.head_mem⟩)
-  cases CoreChaseDerivation.trigger_introducing_functional_term_occurs_in_chase start_eq start_finite node t_mem_node t_mem_trg with
-  | inl t_mem => apply False.elim; exact cb.func_term_not_mem_head (PreTrigger.term_functional_of_mem_fresh_terms _ t_mem_trg) t_mem
-  | inr t_mem => exact t_mem
+  have t_nmem_head : t ∉ cb.head.core.terms := by
+    intro t_mem
+    exact cb.func_term_not_mem_head (PreTrigger.term_functional_of_mem_fresh_terms _ t_mem_trg) t_mem
+  cases ChaseDerivation.mem_iff_eq_head_or_mem_tail.mp node.property with
+  | inl node_mem =>
+    rw [node_mem, ← cb.head.ingoingFacts_eq, cb.database_first'.left, ← cb.database_first'.right.left] at t_mem_node
+    apply False.elim; apply t_nmem_head; exact t_mem_node
+  | inr node_mem =>
+    have start_finite := (cb.core_finite_of_mem ⟨_, cb.head_mem⟩)
+    rcases node_mem with ⟨next_some, node_mem⟩
+    cases CoreChaseDerivation.trigger_introducing_functional_term_occurs_in_chase start_finite ⟨node.val, node_mem⟩ t_mem_node t_mem_trg with
+    | inl t_mem => apply False.elim; exact t_nmem_head t_mem
+    | inr t_mem =>
+      rcases t_mem with ⟨node2, prec, t_mem⟩
+      have suf : (cb.tail next_some) <:+ cb.toChaseDerivation := PossiblyInfiniteList.IsSuffix_tail
+      exact ⟨_, ChaseDerivationSkeleton.predecessor_of_suffix suf prec, t_mem⟩
 
 end TermsInChase
 

--- a/ExistentialRules/ChaseSequence/CoreChase/CoreChaseBranch.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/CoreChaseBranch.lean
@@ -638,6 +638,7 @@ theorem origin_trg_remains_inactive {cb : CoreChaseBranch kb} {n1 n2 : cb.Node} 
   rw [cb.predecessor_iff] at prec; rcases prec with ⟨cd, suf, n1_eq, n2_mem⟩
   cases cd.mem_iff_eq_head_or_mem_tail.mp n2_mem with
   | inl n2_mem =>
+    -- We have shown the base case (n1 = n2) in a separate result on `CoreChaseNode`.
     apply n1.val.equiv_origin_trg_inactive_for_own_core_of_finite (cb.core_finite_of_mem n1) _ orig_mem _ equiv
     rw [← n1_eq, ← n2_mem]
     exact contra
@@ -824,42 +825,24 @@ theorem origin_trg_remains_inactive {cb : CoreChaseBranch kb} {n1 n2 : cb.Node} 
       intro frontier_still_occurs
       apply none_loaded_n3
       rcases prop_still_true_on_n3_facts with ⟨trg', equiv', loaded'⟩
-      rcases n3.val.homSubset.right with ⟨h, hom⟩
 
-      -- the following is repeating a lot from similar proofs found in CoreChaseNode
-      have h_endo : h.isHomomorphism n3.val.core n3.val.core := by
-        constructor; exact hom.left
-        apply Set.subset_trans _ hom.right
-        apply TermMapping.apply_generalized_atom_set_subset_of_subset
-        exact n3.val.homSubset.left
+      rcases ex_hom_that_is_id_on_terms_of_isWeakCore_of_homSubset_of_finite n3.val.isWeakCore n3.val.homSubset (cb.core_finite_of_mem n3)
+        with ⟨h, hom, id_on_terms⟩
 
-      have node_strong_core : n3.val.core.isStrongCore := n3.val.core.isStrongCore_of_isWeakCore_of_finite n3.val.isWeakCore (cb.core_finite_of_mem n3)
-      have endo_surj : h.surjectiveSet n3.val.core.terms n3.val.core.terms := (node_strong_core h h_endo).right.right
-      rcases n3.val.core.terms_finite_of_finite (cb.core_finite_of_mem n3) with ⟨terms, _, terms_eq⟩
-      have terms_eq : ∀ t, t ∈ n3.val.core.terms ↔ t ∈ terms := by intro _; rw [terms_eq]
-      rw [Function.surjective_set_list_equiv terms_eq terms_eq] at endo_surj
-      rcases h.exists_repetition_that_is_inverse_of_surj terms endo_surj with ⟨k, inv⟩
-      let target_h : GroundTermMapping sig := (h.repeat_fun k) ∘ h
-      have target_h_hom : target_h.isHomomorphism n3.val.facts n3.val.core := by
-        apply GroundTermMapping.isHomomorphism_compose; exact hom; exact GroundTermMapping.repeat_isHomomorphism h_endo k
-      have target_h_id_terms : ∀ t ∈ terms, target_h t = t := inv
-      -- here is starts being different again
-
-      let target_trg : Trigger (RestrictedObsolescence sig) := { rule := trg'.val.rule, subs := target_h ∘ trg'.val.subs}
+      let target_trg : Trigger (RestrictedObsolescence sig) := { rule := trg'.val.rule, subs := h ∘ trg'.val.subs}
       exists ⟨target_trg, trg'.property⟩; constructor
       . constructor
         . rw [equiv'.left]
         . intro v v_mem
           rw [equiv'.right _ v_mem]
           simp only [target_trg, Function.comp_apply]
-          rw [target_h_id_terms]
-          rw [← terms_eq]
+          rw [id_on_terms]
           suffices trg'.val.subs v = trg.val.subs v by
             rw [this]; apply frontier_still_occurs; rw [← equiv.left]; exact v_mem
           rw [← equiv'.right _ v_mem, equiv.right _ v_mem]
       . simp only [PreTrigger.loaded, PreTrigger.mapped_body]
-        rw [GroundSubstitution.apply_function_free_conj_compose_of_isIdOnConstants _ _ target_h_hom.left]
-        apply Set.subset_trans _ target_h_hom.right
+        rw [GroundSubstitution.apply_function_free_conj_compose_of_isIdOnConstants _ _ hom.left]
+        apply Set.subset_trans _ hom.right
         rw [Function.comp_apply]
         rw [← TermMapping.apply_generalized_atom_set_toSet]
         apply TermMapping.apply_generalized_atom_set_subset_of_subset

--- a/ExistentialRules/ChaseSequence/CoreChase/CoreChaseBranch.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/CoreChaseBranch.lean
@@ -633,8 +633,238 @@ For regular chase derivations this is trivial because of fact monotonicity but h
 
 theorem origin_trg_remains_inactive {cb : CoreChaseBranch kb} {n1 n2 : cb.Node} (prec : n1 ≼ n2) :
     ∀ orig ∈ n1.val.origin, ∀ trg, orig.fst.equiv trg -> ¬ trg.val.active n2.val.core := by
-  -- part of this can be proven with CoreChaseNode.origin_trg_inactive_for_own_core_of_finite
-  sorry
+  -- We assume for a contradiction that trg is active on n2 (captured in contra).
+  intro orig orig_mem trg equiv contra
+  rw [cb.predecessor_iff] at prec; rcases prec with ⟨cd, suf, n1_eq, n2_mem⟩
+  cases cd.mem_iff_eq_head_or_mem_tail.mp n2_mem with
+  | inl n2_mem =>
+    apply n1.val.equiv_origin_trg_inactive_for_own_core_of_finite (cb.core_finite_of_mem n1) _ orig_mem _ equiv
+    rw [← n1_eq, ← n2_mem]
+    exact contra
+  | inr n2_mem =>
+    -- We get the node that is just before n1 and show some of its essential properties.
+    rcases cb.mem_tail_of_isSome_origin n1.property (by simp only [ChaseNode.origin]; rw [orig_mem]; simp) with ⟨_, n1_mem_tail⟩
+    rcases cb.mem_tail_iff.mp n1_mem_tail with ⟨(cd_where_n1_next : CoreChaseDerivation kb.rules), cd_where_n1_next_suf, n1_next⟩
+    let just_before_n1 : cb.Node := ⟨cd_where_n1_next.head, cd_where_n1_next.mem_of_mem_suffix cd_where_n1_next_suf _ cd_where_n1_next.head_mem⟩
+    have just_before_n1_prec : just_before_n1 ≺ n1 := by
+      have prec := (cd_where_n1_next.head_strict_prec_next_of_finite (cb.core_finite_of_mem just_before_n1) n1_next)
+      constructor
+      . exact cd_where_n1_next.predecessor_of_suffix cd_where_n1_next_suf prec.left
+      . intro contra; rw [Subtype.mk.injEq] at contra; apply prec.right; rw [Subtype.mk.injEq]; exact contra
+    have orig_active_just_before_n1 : orig.fst.val.active just_before_n1.val.core := by
+      have active := cd_where_n1_next.active_trigger_origin_next n1_next
+      rw [Option.mem_def] at orig_mem
+      simp only [ChaseNode.origin, orig_mem, Option.get_some] at active
+      apply active
+    -- We also get the node that is just before n2 and show some of its essential properties.
+    rcases n2_mem with ⟨_, n2_mem⟩; rw [cd.mem_tail_iff] at n2_mem
+    rcases n2_mem with ⟨cd_where_n2_next, cd_where_n2_next_suf, n2_next⟩
+    let just_before_n2 : cb.Node := ⟨cd_where_n2_next.head, cd_where_n2_next.mem_of_mem_suffix (PossiblyInfiniteList.IsSuffix_trans cd_where_n2_next_suf suf) _ cd_where_n2_next.head_mem⟩
+    have just_before_n2_succ : n1 ≼ just_before_n2 := by
+      rw [cb.predecessor_iff]; exists cd; constructor; exact suf
+      constructor; exact n1_eq; exact cd_where_n2_next.mem_of_mem_suffix cd_where_n2_next_suf _ cd_where_n2_next.head_mem
+    -- The following is used in the proof but also required to prove termination of the recursive theorem.
+    have just_before_n2_prec : just_before_n2 ≺ n2 := by
+      have prec := (CoreChaseDerivation.head_strict_prec_next_of_finite (cb.core_finite_of_mem just_before_n2) n2_next)
+      constructor
+      . exact cd_where_n2_next.predecessor_of_suffix (PossiblyInfiniteList.IsSuffix_trans cd_where_n2_next_suf suf) prec.left
+      . intro contra; rw [Subtype.mk.injEq] at contra; apply prec.right; rw [Subtype.mk.injEq]; exact contra
+    -- From a recursive call to the theorem, we get that no equivalent trigger can be active on just_before_n2.
+    have no_trg_active_head_cd2 : ∀ trg, orig.fst.equiv trg -> ¬ trg.val.active just_before_n2.val.core := origin_trg_remains_inactive just_before_n2_succ _ orig_mem
+    -- If however there is an equivalent trigger loaded just_before_n2, then we can quickly conclude the proof
+    -- by showing that this trigger would then in fact be active on just_before_n2, which is a contradiction.
+    -- Or rather: if it was not active, then we can show that trg is obsolete on n2,
+    -- but this contradicts our assumption made in the beginning.
+    cases Classical.em (∃ trg, orig.fst.equiv trg ∧ trg.val.loaded just_before_n2.val.core) with
+    | inl ex_loaded_trg =>
+      rcases ex_loaded_trg with ⟨loaded_trg, loaded_trg_equiv, loaded_trg_loaded⟩
+      apply no_trg_active_head_cd2 loaded_trg loaded_trg_equiv
+      constructor; exact loaded_trg_loaded; intro loaded_trg_obs
+      apply contra.right
+      apply equiv_trg_obsolete_of_isWeakCore_of_homSubset_of_finite n2.val.isWeakCore n2.val.homSubset (cb.core_finite_of_mem n2) _ _ _ (PreTrigger.equiv_trans (PreTrigger.equiv_symm loaded_trg_equiv) equiv) contra.left
+      apply PreTrigger.satisfied_of_satisfied_subset _ loaded_trg_obs
+      rw [← n2.val.ingoingFacts_eq, cd_where_n2_next.facts_next n2_next]
+      apply Set.subset_union_of_subset_left
+      rw [cd_where_n2_next.head.outgoingFacts_eq]
+      exact Set.subset_refl
+    | inr ex_loaded_trg =>
+      -- If no equivalent trigger is loaded just_before_n2, things get more complicated...
+      -- First, we obtain the first node after n1, where no equivalent trigger is loaded; call that n3.
+      let target_prop (node : cb.Node) : Prop :=
+        n1 ≼ node ∧ ¬ ∃ trg, orig.fst.equiv trg ∧ trg.val.loaded node.val.core
+      rcases cb.prop_for_node_has_minimal_such_node target_prop just_before_n2 ⟨just_before_n2_succ, ex_loaded_trg⟩ with ⟨n3, ⟨n3_prec, none_loaded_n3⟩, n3_minimal⟩
+
+      -- Now let's assume for a second that we can find a frontier term that is not part of n3's core.
+      suffices ∃ v ∈ trg.val.rule.frontier, trg.val.subs v ∉ n3.val.core.terms by
+        -- We know a couple things about such a term:
+        -- 1. it must occur in just_before_n1 and n2 because the equivalent triggers are loaded there, and
+        -- 2. it must be a functional term since constants can never be removed.
+        rcases this with ⟨v, v_mem, t_nmem⟩
+        have t_mem_core_cd_where_n1_next : trg.val.subs v ∈ cd_where_n1_next.head.core.terms := by
+          apply FactSet.terms_subset_of_subset orig_active_just_before_n1.left
+          rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]; apply Or.inr
+          exists v; constructor
+          . apply Rule.frontier_subset_vars_body; rw [equiv.left]; exact v_mem
+          . apply equiv.right; rw [equiv.left]; exact v_mem
+        have t_mem_facts_cd_where_n1_next : trg.val.subs v ∈ cd_where_n1_next.head.facts.terms := by
+          apply FactSet.terms_subset_of_subset cd_where_n1_next.head.homSubset.left
+          exact t_mem_core_cd_where_n1_next
+        have t_mem_facts_n2 : trg.val.subs v ∈ n2.val.facts.terms := by
+          apply FactSet.terms_subset_of_subset (Set.subset_trans contra.left n2.val.homSubset.left)
+          rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]; apply Or.inr
+          exists v; constructor
+          . apply Rule.frontier_subset_vars_body; exact v_mem
+          . rfl
+        have t_func : ∃ func ts arity_ok, trg.val.subs v = .func func ts arity_ok := by
+          cases eq : trg.val.subs v with
+          | func func ts arity_ok => exists func, ts, arity_ok
+          | const c =>
+            exfalso
+            apply t_nmem
+            rcases CoreChaseDerivation.exists_homomorphism_of_prec (cb.predecessor_trans just_before_n1_prec.left n3_prec) with ⟨h, hom⟩
+            suffices h (trg.val.subs v) ∈ n3.val.core.terms by
+              rw [eq]; rw [eq, hom.left] at this; exact this
+            apply FactSet.terms_subset_of_subset hom.right
+            rw [h.terms_applyFactSet]
+            apply Set.mem_map_of_mem
+            exact t_mem_core_cd_where_n1_next
+        -- We also know that n3 strictly occurs before n2 (because it occurs before just_before_n2).
+        -- The argument is a bit more elaborate then one might think.
+        have n3_prec_n2 : n3 ≺ n2 := by
+          suffices n3 ≼ just_before_n2 by exact cb.strict_prec_of_prec_of_strict_prec this just_before_n2_prec
+          suffices ¬ just_before_n2 ≺ n3 by
+            cases cb.predecessor_total n3 just_before_n2 with
+            | inl prec => exact prec
+            | inr prec =>
+              cases cb.eq_or_strict_of_predecessor prec with
+              | inl eq => rw [eq]; grind
+              | inr prec => exfalso; apply this; exact prec
+          intro contra
+          apply n3_minimal just_before_n2 contra
+          constructor
+          . exact just_before_n2_succ
+          . exact ex_loaded_trg
+        rcases (cb.predecessor_iff _ _).mp n3_prec_n2.left with ⟨cd3, suf', cd3_head, n2_mem_cd3⟩
+
+        -- Since the frontier term in question occurs in just_before_n1,
+        -- it must have been introduced by a trigger before.
+        rcases cb.functional_term_originates_from_some_trigger just_before_n1 t_func t_mem_facts_cd_where_n1_next with ⟨t_orig_node_before_n1, t_orig_node_before_n1_prec, t_orig_before_n1, t_orig_before_n1_mem, t_mem_orig_before_n1⟩
+
+        cases cd3.mem_iff_eq_head_or_mem_tail.mp n2_mem_cd3 with
+        | inl contra => exfalso; apply n3_prec_n2.right; rw [Subtype.mk.injEq, contra, cd3_head]
+        | inr n2_mem_cd3 =>
+          rcases n2_mem_cd3 with ⟨cd3_next_some, n2_mem_cd3⟩
+          -- Similarly, the term needs to be introduced again on the way from n3 to n2 by an equivalent trigger.
+          cases CoreChaseDerivation.trigger_introducing_functional_term_occurs_in_chase (cd := cd3)
+            (by rw [cd3_head]; apply cb.core_finite_of_mem)
+            ⟨n2.val, n2_mem_cd3⟩
+            t_mem_facts_n2
+            t_mem_orig_before_n1 with
+          | inl contra => apply t_nmem; rw [← cd3_head]; exact contra
+          | inr trg_occurs_again =>
+            -- Now for the rest of this subproof we just apply our theorem recursively to conclude
+            -- the proof as we now found two nodes where a trigger is applied twice (up to equivalence).
+            -- The recursive call is fine since the first occurrence is before n1, so the first node is decreasing.
+            rcases trg_occurs_again with ⟨t_orig_node_after_n3, t_orig_node_after_n3_prec, t_orig_after_n3, t_orig_after_n3_mem, t_orig_trgs_equiv, t_mem_orig_after_n3⟩
+            rcases cd3.mem_tail_iff.mp t_orig_node_after_n3.property with ⟨cd4, cd4_suf, cd4_next_eq⟩
+            have t_orig_nodes_prec : t_orig_node_before_n1 ≼ ⟨cd4.head, by apply cd4.mem_of_mem_suffix _ _ cd4.head_mem; exact PossiblyInfiniteList.IsSuffix_trans cd4_suf suf'⟩ := by
+              apply cb.predecessor_trans t_orig_node_before_n1_prec
+              apply cb.predecessor_trans just_before_n1_prec.left
+              apply cb.predecessor_trans n3_prec
+              rw [cb.predecessor_iff]
+              exists cd3; constructor; exact suf'
+              constructor; exact cd3_head
+              apply cd4.mem_of_mem_suffix cd4_suf
+              exact cd4.head_mem
+            have _term : t_orig_node_before_n1 ≺ n1 := by
+              exact cb.strict_prec_of_prec_of_strict_prec t_orig_node_before_n1_prec just_before_n1_prec
+            apply origin_trg_remains_inactive t_orig_nodes_prec _ t_orig_before_n1_mem _ (PreTrigger.equiv_symm t_orig_trgs_equiv)
+            suffices t_orig_after_n3 = t_orig_node_after_n3.val.origin.get (cd4.isSome_origin_next cd4_next_eq) by
+              rw [this]; exact cd4.active_trigger_origin_next cd4_next_eq
+            rw [Option.mem_def] at t_orig_after_n3_mem
+            simp [t_orig_after_n3_mem]
+      -- It remains to be shown now that indeed some frontier term cannot be part of n3's core.
+      -- First, we prove that on n3's facts, some equivalent trigger is still loaded
+      -- (meaning that all frontier terms must still be there).
+      -- This means that n3 is the exact node where the frontier term gets removed when taking the core.
+      have prop_still_true_on_n3_facts : ∃ trg, orig.fst.equiv trg ∧ trg.val.loaded n3.val.facts := by
+        rw [cb.predecessor_iff] at n3_prec; rcases n3_prec with ⟨cd3, cd3_suf, n1_eq_cd3_head, n3_mem⟩
+        cases cd3.mem_iff_eq_head_or_mem_tail.mp n3_mem with
+        | inl n3_mem =>
+          exists orig.fst; constructor; exact PreTrigger.equiv_refl
+          rw [n3_mem, n1_eq_cd3_head]
+          apply Set.subset_trans orig_active_just_before_n1.left
+          rw [← n1.val.ingoingFacts_eq, cd_where_n1_next.facts_next n1_next]
+          apply Set.subset_union_of_subset_left
+          exact Set.subset_refl
+        | inr n3_mem =>
+          rcases n3_mem with ⟨_, n3_mem⟩; rw [cd3.mem_tail_iff] at n3_mem
+          rcases n3_mem with ⟨cd4, cd4_suf, n3_mem⟩
+          let cd4_head_node : cb.Node := ⟨cd4.head, cd4.mem_of_mem_suffix (PossiblyInfiniteList.IsSuffix_trans cd4_suf cd3_suf) _ cd4.head_mem⟩
+          have cd4_head_node_succ : n1 ≼ cd4_head_node := by
+            rw [cb.predecessor_iff]; exists cd3; constructor; exact cd3_suf
+            constructor; exact n1_eq_cd3_head; exact cd4.mem_of_mem_suffix cd4_suf _ cd4.head_mem
+          have prec := CoreChaseDerivation.head_strict_prec_next_of_finite (cb.core_finite_of_mem cd4_head_node) n3_mem
+          specialize n3_minimal cd4_head_node (by
+            constructor
+            . exact cd4.predecessor_of_suffix (PossiblyInfiniteList.IsSuffix_trans cd4_suf cd3_suf) prec.left
+            . intro contra; apply prec.right; rw [Subtype.mk.injEq] at contra; rw [Subtype.mk.injEq]; exact contra)
+          unfold target_prop at n3_minimal
+          simp only [not_and, Classical.not_not] at n3_minimal
+          rcases n3_minimal cd4_head_node_succ with ⟨trg, equiv, loaded⟩
+          exists trg; constructor; exact equiv
+          rw [← n3.val.ingoingFacts_eq, cd4.facts_next n3_mem]
+          apply Set.subset_union_of_subset_left
+          exact loaded
+      -- Now let's assume for a contradiction that all frontier terms are still part of n3's core.
+      -- The idea for the rest of the proof is the following:
+      -- There is a homomorphism from n3's facts to its core. If all frontier terms still occur in the core, then we can repeat this homomorphism to just be the identity on these terms. But then this repeated homomorphism can be used to build an equivalent trigger that is loaded on n3's core, which yields the desired contradiction.
+      apply Classical.byContradiction
+      simp only [not_exists, not_and, Classical.not_not]
+      intro frontier_still_occurs
+      apply none_loaded_n3
+      rcases prop_still_true_on_n3_facts with ⟨trg', equiv', loaded'⟩
+      rcases n3.val.homSubset.right with ⟨h, hom⟩
+
+      -- the following is repeating a lot from similar proofs found in CoreChaseNode
+      have h_endo : h.isHomomorphism n3.val.core n3.val.core := by
+        constructor; exact hom.left
+        apply Set.subset_trans _ hom.right
+        apply TermMapping.apply_generalized_atom_set_subset_of_subset
+        exact n3.val.homSubset.left
+
+      have node_strong_core : n3.val.core.isStrongCore := n3.val.core.isStrongCore_of_isWeakCore_of_finite n3.val.isWeakCore (cb.core_finite_of_mem n3)
+      have endo_surj : h.surjectiveSet n3.val.core.terms n3.val.core.terms := (node_strong_core h h_endo).right.right
+      rcases n3.val.core.terms_finite_of_finite (cb.core_finite_of_mem n3) with ⟨terms, _, terms_eq⟩
+      have terms_eq : ∀ t, t ∈ n3.val.core.terms ↔ t ∈ terms := by intro _; rw [terms_eq]
+      rw [Function.surjective_set_list_equiv terms_eq terms_eq] at endo_surj
+      rcases h.exists_repetition_that_is_inverse_of_surj terms endo_surj with ⟨k, inv⟩
+      let target_h : GroundTermMapping sig := (h.repeat_fun k) ∘ h
+      have target_h_hom : target_h.isHomomorphism n3.val.facts n3.val.core := by
+        apply GroundTermMapping.isHomomorphism_compose; exact hom; exact GroundTermMapping.repeat_isHomomorphism h_endo k
+      have target_h_id_terms : ∀ t ∈ terms, target_h t = t := inv
+      -- here is starts being different again
+
+      let target_trg : Trigger (RestrictedObsolescence sig) := { rule := trg'.val.rule, subs := target_h ∘ trg'.val.subs}
+      exists ⟨target_trg, trg'.property⟩; constructor
+      . constructor
+        . rw [equiv'.left]
+        . intro v v_mem
+          rw [equiv'.right _ v_mem]
+          simp only [target_trg, Function.comp_apply]
+          rw [target_h_id_terms]
+          rw [← terms_eq]
+          suffices trg'.val.subs v = trg.val.subs v by
+            rw [this]; apply frontier_still_occurs; rw [← equiv.left]; exact v_mem
+          rw [← equiv'.right _ v_mem, equiv.right _ v_mem]
+      . simp only [PreTrigger.loaded, PreTrigger.mapped_body]
+        rw [GroundSubstitution.apply_function_free_conj_compose_of_isIdOnConstants _ _ target_h_hom.left]
+        apply Set.subset_trans _ target_h_hom.right
+        rw [Function.comp_apply]
+        rw [← TermMapping.apply_generalized_atom_set_toSet]
+        apply TermMapping.apply_generalized_atom_set_subset_of_subset
+        exact loaded'
+termination_by (n1, n2)
 
 end OriginTriggerRemainsInactive
 

--- a/ExistentialRules/ChaseSequence/CoreChase/CoreChaseBranch.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/CoreChaseBranch.lean
@@ -213,6 +213,26 @@ theorem strict_predecessor_trans_of_finite {cd : CoreChaseDerivation rules} {n1 
   . exact predecessor_trans_of_finite n2_fin prec1.left prec2.left
   . grind
 
+/-- The strict predecessor relation is transitive with respect to the regular predecessor relation. -/
+@[grind ->]
+theorem strict_prec_of_prec_of_strict_prec_of_finite {cd : CoreChaseDerivation rules} {n1 n2 n3 : cd.Node}
+    (n1_fin : n1.val.core.finite) (n2_fin : n2.val.core.finite) :
+    n1 ≼ n2 -> n2 ≺ n3 -> n1 ≺ n3 := by
+  intro prec1 prec2
+  constructor
+  . exact predecessor_trans_of_finite n2_fin prec1 prec2.left
+  . cases cd.eq_or_strict_of_predecessor prec1 <;> grind
+
+/-- The strict predecessor relation is transitive with respect to the regular predecessor relation. -/
+@[grind ->]
+theorem strict_prec_of_strict_prec_of_prec_of_finite {cd : CoreChaseDerivation rules} {n1 n2 n3 : cd.Node}
+    (n1_fin : n1.val.core.finite) (n2_fin : n2.val.core.finite) :
+    n1 ≺ n2 -> n2 ≼ n3 -> n1 ≺ n3 := by
+  intro prec1 prec2
+  constructor
+  . exact predecessor_trans_of_finite n2_fin prec1.left prec2
+  . cases cd.eq_or_strict_of_predecessor prec2 <;> grind
+
 /-- The `ChaseDerivationSkeleton.head` is a strict predecessor of `ChaseDerivationSkeleton.next`. -/
 theorem head_strict_prec_next_of_finite {cd : CoreChaseDerivation rules} (head_fin : cd.head.core.finite) :
     ∀ {next}, (mem : next ∈ cd.next) -> ⟨cd.head, cd.head_mem⟩ ≺ ⟨next, cd.next_mem_of_mem _ mem⟩ := by
@@ -419,6 +439,18 @@ theorem strict_predecessor_asymmetric {cb : CoreChaseBranch kb} {n1 n2 : cb.Node
 @[grind ->]
 theorem strict_predecessor_trans {cb : CoreChaseBranch kb} {n1 n2 n3 : cb.Node} : n1 ≺ n2 -> n2 ≺ n3 -> n1 ≺ n3 := by
   apply CoreChaseDerivation.strict_predecessor_trans_of_finite <;> apply core_finite_of_mem
+
+/-- The strict predecessor relation is transitive with respect to the regular predecessor relation. -/
+@[grind ->]
+theorem strict_prec_of_prec_of_strict_prec {cb : CoreChaseBranch kb} {n1 n2 n3 : cb.Node} :
+    n1 ≼ n2 -> n2 ≺ n3 -> n1 ≺ n3 := by
+  apply CoreChaseDerivation.strict_prec_of_prec_of_strict_prec_of_finite <;> apply core_finite_of_mem
+
+/-- The strict predecessor relation is transitive with respect to the regular predecessor relation. -/
+@[grind ->]
+theorem strict_prec_of_strict_prec_of_prec {cb : CoreChaseBranch kb} {n1 n2 n3 : cb.Node} :
+    n1 ≺ n2 -> n2 ≼ n3 -> n1 ≺ n3 := by
+  apply CoreChaseDerivation.strict_prec_of_strict_prec_of_prec_of_finite <;> apply core_finite_of_mem
 
 /-- The `ChaseDerivationSkeleton.head` is a strict predecessor of `ChaseDerivationSkeleton.next`. -/
 theorem head_strict_prec_next {cb : CoreChaseBranch kb} :

--- a/ExistentialRules/ChaseSequence/CoreChase/CoreChaseNode.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/CoreChaseNode.lean
@@ -22,24 +22,17 @@ variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq 
 section AuxiliaryResultsForTriggerSatisfaction
 
 /-!
-## Trigger Satisfaction along finite `homSubset`s.
+## Homomorphism Repetition in `homSubset`s
 
-Given a few extra conditions, trigger satisfaction is preserved along the `homSubset` relation.
-This is helpful for the `CoreChaseNode` later on as each node features a `homSubset` internally.
+As a very general insight we prove that we can repeat a homomorphism from a `homSubset` relation
+such that the repeated mapping is still a homomorphism but at the same time the id on all terms that occur in the subset.
+This works if the subset is finite.
 -/
 
-/-- If a trigger is satisfied for fs and all of its frontier terms still occur in a finite core homSubset of fs, then the trigger is also satisfied in this homSubset. -/
-theorem trg_remains_obsolete_of_isWeakCore_of_homSubset_of_finite
+/-- If core is a finite weak core and a `homSubset` of fs, then there is a homomorphism from fs to core that is the identity on all of core's terms. -/
+theorem ex_hom_that_is_id_on_terms_of_isWeakCore_of_homSubset_of_finite
     {fs core : FactSet sig} (wc : core.isWeakCore) (homSub : core.homSubset fs) (fin : core.finite) :
-    ∀ (trg : PreTrigger sig), trg.satisfied fs -> (trg.rule.frontier.map trg.subs).toSet ⊆ core.terms -> trg.satisfied core := by
-  intro trg trg_sat frontier_in_core
-
-  rcases trg_sat with ⟨idx, trg_sat⟩
-  exists idx
-
-  -- the first trigger is satisfied
-  rcases trg_sat with ⟨subs, trg_sat⟩
-
+    ∃ (h : GroundTermMapping sig), h.isHomomorphism fs core ∧ ∀ t ∈ core.terms, h t = t := by
   -- we have a homomorphism from fs to core; because of core is a homSubset of fs,
   -- it is even an endomorphism on core
   rcases homSub.right with ⟨h, hom⟩
@@ -62,17 +55,41 @@ theorem trg_remains_obsolete_of_isWeakCore_of_homSubset_of_finite
   have target_h_hom : target_h.isHomomorphism fs core := by
     apply GroundTermMapping.isHomomorphism_compose; exact hom; exact GroundTermMapping.repeat_isHomomorphism h_endo k
   have target_h_id_terms : ∀ t ∈ terms, target_h t = t := inv
+  exists target_h; constructor; exact target_h_hom
+  intro t t_mem; apply target_h_id_terms
+  rw [← terms_eq]; exact t_mem
 
-  -- we can use the repeated homomorphism together with the substitution that witnesses satisfaction to see that the trigger is also satisfied in core but this yields exactly the contridiction that we were looking for
-  exists target_h ∘ subs; constructor
-  . intro v v_mem; rw [Function.comp_apply, trg_sat.left v v_mem, target_h_id_terms]
-    rw [← terms_eq]
+/-!
+## Trigger Satisfaction along finite `homSubset`s.
+
+Given a few extra conditions, trigger satisfaction is preserved along the `homSubset` relation.
+This is helpful for the `CoreChaseNode` later on as each node features a `homSubset` internally.
+-/
+
+/-- If a trigger is satisfied for fs and all of its frontier terms still occur in a finite core homSubset of fs, then the trigger is also satisfied in this homSubset. -/
+theorem trg_remains_obsolete_of_isWeakCore_of_homSubset_of_finite
+    {fs core : FactSet sig} (wc : core.isWeakCore) (homSub : core.homSubset fs) (fin : core.finite) :
+    ∀ (trg : PreTrigger sig), trg.satisfied fs -> (trg.rule.frontier.map trg.subs).toSet ⊆ core.terms -> trg.satisfied core := by
+  intro trg trg_sat frontier_in_core
+
+  rcases trg_sat with ⟨idx, trg_sat⟩
+  exists idx
+
+  -- the first trigger is satisfied
+  rcases trg_sat with ⟨subs, trg_sat⟩
+
+  -- we have a homomorphism from fs to core that is the identity on the terms in core
+  rcases ex_hom_that_is_id_on_terms_of_isWeakCore_of_homSubset_of_finite wc homSub fin with ⟨h, hom, id_on_terms⟩
+
+  -- we can use the homomorphism together with the substitution that witnesses satisfaction to see that the trigger is also satisfied in core but this yields exactly the contridiction that we were looking for
+  exists h ∘ subs; constructor
+  . intro v v_mem; rw [Function.comp_apply, trg_sat.left v v_mem, id_on_terms]
     apply frontier_in_core; rw [List.mem_toSet]; apply List.mem_map_of_mem v_mem
-  . rw [GroundSubstitution.apply_function_free_conj_compose_of_isIdOnConstants _ _ target_h_hom.left]
+  . rw [GroundSubstitution.apply_function_free_conj_compose_of_isIdOnConstants _ _ hom.left]
     intro f f_mem
     rw [List.mem_toSet, Function.comp_apply, TermMapping.mem_apply_generalized_atom_list] at f_mem
     rcases f_mem with ⟨intermediate, intermediate_mem, f_eq⟩
-    apply target_h_hom.right
+    apply hom.right
     rw [f_eq]
     apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_set
     apply trg_sat.right

--- a/ExistentialRules/ChaseSequence/TreeDerivation.lean
+++ b/ExistentialRules/ChaseSequence/TreeDerivation.lean
@@ -246,6 +246,39 @@ theorem childNodes_eq {td : TreeDerivation N obs rules} : td.childNodes = td.chi
 theorem IsSuffix_of_mem_childTrees {td : TreeDerivation N obs rules} : ∀ td2 ∈ td.childTrees, td2 <:+ td := by
   intro td2 mem; apply FiniteDegreeTree.IsSuffix_of_mem_childTrees td2.toFiniteDegreeTreeWithRoot; rw [← mem_childTrees_iff]; exact mem
 
+/-- A node is a member if and only if it is either the root or it is a member of a child tree. -/
+theorem mem_iff_eq_root_or_mem_child {td : TreeDerivation N obs rules} {node : N} :
+    node ∈ td ↔ node = td.root ∨ ∃ child ∈ td.childTrees, node ∈ child := by
+  constructor
+  . rw [mem_iff]
+    intro ⟨ns, mem⟩
+    cases ns with
+    | nil => apply Or.inl; simp [root, FiniteDegreeTree.root_eq, mem]
+    | cons n ns =>
+      apply Or.inr
+      have lt : n < td.childTrees.length := by
+        simp only [TreeDerivation.childTrees, List.length_map, List.length_attach]
+        suffices td.tree.childTrees[n]? ≠ none by
+          apply Decidable.byContradiction
+          intro le
+          apply this
+          rw [List.getElem?_eq_none_iff]
+          exact Nat.le_of_not_lt le
+        intro contra
+        rw [FiniteDegreeTree.get?_childTrees, FiniteDegreeTree.FiniteDegreeTreeWithRoot.tree_to_opt_none_iff, ← FiniteDegreeTree.empty_iff_root_none] at contra
+        suffices (td.tree.drop [n]).get? ns = some node by
+          rw [contra, FiniteDegreeTree.get?_empty] at this; simp at this
+        rw [FiniteDegreeTree.get?_drop, List.singleton_append]
+        exact mem
+      exists td.childTrees[n]; constructor
+      . simp
+      . rw [mem_iff]
+        exists ns
+        simpa [childTrees, derivation_for_suffix] using mem
+  . intro or; cases or with
+    | inl eq_root => rw [eq_root]; exact td.root_mem
+    | inr mem_child => rcases mem_child with ⟨_, mem_child⟩; apply mem_of_mem_suffix _ _ mem_child.right; exact td.IsSuffix_of_mem_childTrees _ mem_child.left
+
 /-- A derivation is a subtree of another if and only if both are the same or the first is a suffix of one of the second's child trees. -/
 theorem suffix_iff_eq_or_suffix_childTree {td1 td2 : TreeDerivation N obs rules} : td1 <:+ td2 ↔ td1 = td2 ∨ ∃ td3 ∈ td2.childTrees, td1 <:+ td3 := by
   constructor
@@ -452,6 +485,44 @@ theorem triggers_exist {td : TreeDerivation N obs rules} (node : td.NodeWithAddr
   apply trg_ex
   suffices node.node = node.subderivation.root by rw [this]; unfold TreeDerivation.root; simp
   simp
+
+/-- A node is a member if and only if it is either the root or it is a member of a child tree. -/
+theorem eq_root_or_mem_child {td : TreeDerivation N obs rules} {node : td.NodeWithAddress} :
+    node = NodeWithAddress.root td ∨ ∃ child ∈ NodeWithAddress.childNodes (NodeWithAddress.root td), ∃ node' : child.subderivation.NodeWithAddress, cast_for_new_root_node child node' = node := by
+  cases addr_eq : node.address with
+  | nil => apply Or.inl; apply eq_of_address_eq; simpa [root] using addr_eq
+  | cons n ns =>
+    apply Or.inr
+    have lt : n < (root td).childNodes.length := by
+      rw [length_childNodes, subderivation_root]
+      simp only [TreeDerivation.childNodes, FiniteDegreeTree.length_childNodes]
+      suffices td.tree.childTrees[n]? ≠ none by
+        apply Decidable.byContradiction
+        intro le
+        apply this
+        rw [List.getElem?_eq_none_iff]
+        exact Nat.le_of_not_lt le
+      intro contra
+      rw [FiniteDegreeTree.get?_childTrees, FiniteDegreeTree.FiniteDegreeTreeWithRoot.tree_to_opt_none_iff, ← FiniteDegreeTree.empty_iff_root_none] at contra
+      suffices (td.tree.drop [n]).get? ns = some node.node by
+        rw [contra, FiniteDegreeTree.get?_empty] at this; simp at this
+      rw [FiniteDegreeTree.get?_drop, List.singleton_append, ← addr_eq]
+      exact node.eq
+    exists (root td).childNodes[n]; constructor
+    . simp
+    . exists {
+        node := node.node,
+        address := ns,
+        eq := by
+          simp only [subderivation, derivation_for_suffix]
+          rw [address_getElem_childNodes, ← node.eq, addr_eq]
+          simp [root]
+      }
+      apply eq_of_address_eq
+      simp only [cast_for_new_root_node]
+      rw [address_getElem_childNodes]
+      rw [addr_eq]
+      rfl
 
 end NodeWithAddress
 
@@ -935,131 +1006,137 @@ variable {N : Type u} [CN : ChaseNode N obs rules]
 /-- Constants in the chase can only come from the initial fact set or from a constant in a rule. -/
 theorem constants_node_subset_constants_fs_union_constants_rules
     (out_sub_in : CN.out_sub_in)
-    {td : TreeDerivation N obs rules}
-    (start_eq : CN.ingoingFacts td.root = CN.outgoingFacts td.root)
-    {node : N} (node_mem : node ∈ td) :
+    {td child : TreeDerivation N obs rules}
+    (child_mem : child ∈ td.childTrees)
+    {node : N} (node_mem : node ∈ child) :
     (CN.ingoingFacts node).constants ⊆ ((CN.outgoingFacts td.root).constants ∪ rules.head_constants) := by
   rw [mem_iff] at node_mem
   rcases node_mem with ⟨addr, node_mem⟩
-  let node' : td.NodeWithAddress := {node := node, address := addr, eq := node_mem}
+  let node' : child.NodeWithAddress := {node := node, address := addr, eq := node_mem}
   show (CN.ingoingFacts node'.node).constants ⊆ ((CN.outgoingFacts td.root).constants ∪ rules.head_constants)
-  induction node' using mem_rec_address with
-  | root =>
-    apply Set.subset_union_of_subset_left
-    simp only [NodeWithAddress.root]
-    rw [start_eq]
-    apply Set.subset_refl
-  | step new_root ih c c_mem =>
-    rw [facts_childNodes (NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem), NodeWithAddress.root_subderivation']
+
+  suffices ∀ td2 : TreeDerivation N obs rules, ∀ next ∈ td2.childNodes, (CN.ingoingFacts next).constants ⊆ ((CN.outgoingFacts td2.root).constants ∪ rules.head_constants) by
+    induction node' using mem_rec_address with
+    | root => apply this; rw [td.childNodes_eq]; apply List.mem_map_of_mem; exact child_mem
+    | step new_root ih c c_mem =>
+      specialize this new_root.subderivation c.node (NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem)
+      apply Set.subset_trans this
+      rw [Set.union_subset_iff_both_subset]; constructor
+      . apply Set.subset_trans _ ih; rw [new_root.root_subderivation']; exact FactSet.constants_subset_of_subset out_sub_in
+      . apply Set.subset_union_of_subset_right; exact Set.subset_refl
+
+  intro td2 next next_mem
+  rw [facts_childNodes next_mem]
+  intro d d_mem
+  rw [FactSet.constants_union] at d_mem
+  cases d_mem with
+  | inl d_mem => apply Or.inl; exact d_mem
+  | inr d_mem =>
+    let origin := (CN.origin next).get (isSome_origin_of_mem_childNodes _ next_mem)
+    apply Set.subset_trans (origin.fst.val.mapped_head_constants_subset origin.snd) _ _ d_mem
     intro d d_mem
-    rw [FactSet.constants_union] at d_mem
+    rw [List.mem_toSet, List.mem_append] at d_mem
     cases d_mem with
-    | inl d_mem => apply ih; apply FactSet.constants_subset_of_subset out_sub_in; exact d_mem
+    | inl d_mem =>
+      apply Or.inl
+      rw [List.mem_flatMap] at d_mem
+      rcases d_mem with ⟨t, t_mem, d_mem⟩
+      rw [List.mem_map] at t_mem
+      rcases t_mem with ⟨v, v_mem, t_mem⟩
+      rcases FunctionFreeConjunction.mem_vars.mp (origin.fst.val.rule.frontier_subset_vars_body v_mem) with ⟨a, a_mem, v_mem'⟩
+      exists origin.fst.val.subs.apply_function_free_atom a
+      constructor
+      . have := active_trigger_origin_of_mem_childNodes next_mem
+        apply this.left
+        unfold PreTrigger.mapped_body
+        rw [List.mem_toSet]
+        apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_list
+        exact a_mem
+      . unfold Fact.constants
+        rw [List.mem_flatMap]
+        exists t
+        constructor
+        . unfold GroundSubstitution.apply_function_free_atom
+          unfold TermMapping.apply_generalized_atom
+          rw [List.mem_map]
+          exists VarOrConst.var v
+          constructor
+          . exact v_mem'
+          . unfold PreTrigger.subs_for_mapped_head at t_mem
+            rw [PreTrigger.apply_to_var_or_const_frontier_var _ _ _ v_mem] at t_mem
+            exact t_mem
+        . exact d_mem
     | inr d_mem =>
-      let origin := (CN.origin c.node).get (isSome_origin_of_mem_childNodes _ (NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem))
-      apply Set.subset_trans (origin.fst.val.mapped_head_constants_subset origin.snd)
-      . intro d d_mem
-        rw [List.mem_toSet, List.mem_append] at d_mem
-        cases d_mem with
-        | inl d_mem =>
-          apply ih
-          rw [List.mem_flatMap] at d_mem
-          rcases d_mem with ⟨t, t_mem, d_mem⟩
-          rw [List.mem_map] at t_mem
-          rcases t_mem with ⟨v, v_mem, t_mem⟩
-          rcases FunctionFreeConjunction.mem_vars.mp (origin.fst.val.rule.frontier_subset_vars_body v_mem) with ⟨a, a_mem, v_mem'⟩
-          exists origin.fst.val.subs.apply_function_free_atom a
-          constructor
-          . apply out_sub_in
-            have := active_trigger_origin_of_mem_childNodes (NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem)
-            rw [NodeWithAddress.root_subderivation'] at this
-            apply this.left
-            unfold PreTrigger.mapped_body
-            rw [List.mem_toSet]
-            apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_list
-            exact a_mem
-          . unfold Fact.constants
-            rw [List.mem_flatMap]
-            exists t
-            constructor
-            . unfold GroundSubstitution.apply_function_free_atom
-              unfold TermMapping.apply_generalized_atom
-              rw [List.mem_map]
-              exists VarOrConst.var v
-              constructor
-              . exact v_mem'
-              . unfold PreTrigger.subs_for_mapped_head at t_mem
-                rw [PreTrigger.apply_to_var_or_const_frontier_var _ _ _ v_mem] at t_mem
-                exact t_mem
-            . exact d_mem
-        | inr d_mem =>
-          apply Or.inr
-          exists origin.fst.val.rule
-          constructor
-          . exact origin.fst.property
-          . unfold Rule.head_constants
-            grind
-      . exact d_mem
+      apply Or.inr
+      exists origin.fst.val.rule
+      constructor
+      . exact origin.fst.property
+      . unfold Rule.head_constants
+        grind
 
 /-- Each functional term in the chase originates as a fresh term from a trigger if it was not already part of the initial fact set. -/
 theorem functional_term_originates_from_some_trigger
     (out_sub_in : CN.out_sub_in)
-    {td : TreeDerivation N obs rules}
-    (start_eq : CN.ingoingFacts td.root = CN.outgoingFacts td.root)
-    (node : NodeWithAddress td)
+    {td child : TreeDerivation N obs rules}
+    (child_mem : child ∈ td.childTrees)
+    (node : NodeWithAddress child)
     {t : GroundTerm sig}
     (t_is_func : ∃ func ts arity_ok, t = GroundTerm.func func ts arity_ok)
     (t_mem : t ∈ (CN.ingoingFacts node.node).terms) :
     t ∈ (CN.outgoingFacts td.root).terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ (CN.origin node2.node), t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
-  induction node using mem_rec_address with
-  | root => apply Or.inl; rw [← start_eq]; exact t_mem
-  | step new_root ih c c_mem =>
-    rw [facts_childNodes (NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem), NodeWithAddress.root_subderivation', FactSet.terms_union] at t_mem
-
-    have aux : t ∈ (CN.ingoingFacts new_root.node).terms -> t ∈ (CN.outgoingFacts td.root).terms ∨ ∃ (node2 : td.NodeWithAddress), node2 ≼ c ∧ ∃ orig ∈ (CN.origin node2.node), t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
-      intro t_mem
-      cases ih t_mem with
-      | inl ih => apply Or.inl; exact ih
-      | inr ih =>
-        rcases ih with ⟨node2, prec, t_mem⟩
-        apply Or.inr; exists node2; constructor;
-        . apply predecessor_trans prec; grind
-        . exact t_mem
-
-    cases t_mem with
-    | inl t_mem => exact aux (FactSet.terms_subset_of_subset out_sub_in _ t_mem)
-    | inr t_mem =>
-      unfold ChaseNode.origin_result at t_mem
-      rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_head_iff] at t_mem
-      cases t_mem with
-      | inl t_mem => rcases t_is_func with ⟨func, ts, arity, t_is_func⟩; rcases t_mem with ⟨c, _, t_mem⟩; rw [← t_mem] at t_is_func; have contra := Eq.symm t_is_func; simp [GroundTerm.func_neq_const] at contra
-      | inr t_mem =>
-      cases t_mem with
-      | inr t_mem =>
-        apply Or.inr; exists c; constructor
-        . exact predecessor_refl
-        . exists (CN.origin c.node).get (isSome_origin_of_mem_childNodes _ (NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem))
-          simp only [Option.get_mem, true_and]
-          exact t_mem
+  suffices ∀ td2 : TreeDerivation N obs rules, ∀ next ∈ td2.childNodes, t ∈ (CN.ingoingFacts next).terms -> t ∈ ((CN.outgoingFacts td2.root).terms) ∨ ∃ orig ∈ (CN.origin next), t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) by
+    induction node using mem_rec_address with
+    | root =>
+      cases this td child.root (by rw [childNodes_eq]; apply List.mem_map_of_mem; exact child_mem) t_mem with
+      | inl t_mem => apply Or.inl; exact t_mem
+      | inr t_mem => apply Or.inr; exists NodeWithAddress.root child; constructor; exact predecessor_refl; exact t_mem
+    | step new_root ih c c_mem =>
+      cases this new_root.subderivation c.node (NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem) t_mem with
       | inl t_mem =>
-        apply aux
-        apply FactSet.terms_subset_of_subset out_sub_in
-        have := active_trigger_origin_of_mem_childNodes (NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem)
-        rw [NodeWithAddress.root_subderivation'] at this
-        apply FactSet.terms_subset_of_subset this.left
-        rw [List.mem_map] at t_mem
-        rcases t_mem with ⟨v, v_mem, t_mem⟩
-        rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
-        apply Or.inr
-        exists v; simp only [t_mem, and_true]
-        apply Rule.frontier_subset_vars_body; rw [Rule.mem_frontier_iff_mem_frontier_for_head]; exact ⟨_, ⟨_, v_mem⟩⟩
+        rw [new_root.root_subderivation'] at t_mem
+        cases ih (FactSet.terms_subset_of_subset out_sub_in _ t_mem) with
+        | inl ih => apply Or.inl; exact ih
+        | inr ih =>
+          rcases ih with ⟨node2, prec, t_mem⟩
+          apply Or.inr; exists node2; constructor;
+          . apply predecessor_trans prec
+            exact node_prec_childNodes _ c_mem
+          . exact t_mem
+      | inr t_mem => apply Or.inr; exact ⟨_, predecessor_refl, t_mem⟩
+
+  intro td2 next next_mem t_mem
+  rw [facts_childNodes next_mem, FactSet.terms_union] at t_mem
+  cases t_mem with
+  | inl t_mem => apply Or.inl; exact t_mem
+  | inr t_mem =>
+    unfold ChaseNode.origin_result at t_mem
+    rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_head_iff] at t_mem
+    cases t_mem with
+    | inl t_mem => rcases t_is_func with ⟨func, ts, arity, t_is_func⟩; rcases t_mem with ⟨c, _, t_mem⟩; rw [← t_mem] at t_is_func; have contra := Eq.symm t_is_func; simp [GroundTerm.func_neq_const] at contra
+    | inr t_mem =>
+    cases t_mem with
+    | inr t_mem =>
+      apply Or.inr
+      exists (CN.origin next).get (isSome_origin_of_mem_childNodes _ next_mem)
+      simp only [Option.get_mem, true_and]
+      exact t_mem
+    | inl t_mem =>
+      apply Or.inl
+      have := active_trigger_origin_of_mem_childNodes next_mem
+      apply FactSet.terms_subset_of_subset this.left
+      rw [List.mem_map] at t_mem
+      rcases t_mem with ⟨v, v_mem, t_mem⟩
+      rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
+      apply Or.inr
+      exists v; simp only [t_mem, and_true]
+      apply Rule.frontier_subset_vars_body; rw [Rule.mem_frontier_iff_mem_frontier_for_head]; exact ⟨_, ⟨_, v_mem⟩⟩
 
 /-- If a functional term occurs in the chase, then the trigger that introduces this term must have been used in the chase, unless the term already occurs in the initial fact set. -/
 theorem trigger_introducing_functional_term_occurs_in_chase
     (out_sub_in : CN.out_sub_in)
-    {td : TreeDerivation N obs rules}
-    (start_eq : CN.ingoingFacts td.root = CN.outgoingFacts td.root)
-    (node : NodeWithAddress td)
+    {td child : TreeDerivation N obs rules}
+    (child_mem : child ∈ td.childTrees)
+    (node : NodeWithAddress child)
     {t : GroundTerm sig}
     (t_mem_node : t ∈ (CN.ingoingFacts node.node).terms)
     {trg : RTrigger obs rules}
@@ -1067,7 +1144,7 @@ theorem trigger_introducing_functional_term_occurs_in_chase
     {lt : disj_idx < trg.val.rule.head.length}
     (t_mem_trg : t ∈ trg.val.fresh_terms_for_head_disjunct disj_idx lt) :
     t ∈ (CN.outgoingFacts td.root).terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ (CN.origin node2.node), orig.fst.equiv trg ∧ orig.snd.val = disj_idx := by
-  cases functional_term_originates_from_some_trigger out_sub_in start_eq node (by
+  cases functional_term_originates_from_some_trigger out_sub_in child_mem node (by
     cases eq : t with
     | const _ =>
       rw [eq] at t_mem_trg
@@ -1394,8 +1471,11 @@ theorem constants_node_subset_constants_fs_union_constants_rules
     {td : RegularTreeDerivation obs rules}
     {node : RegularChaseNode obs rules} (node_mem : node ∈ td) :
     node.facts.constants ⊆ (td.root.facts.constants ∪ rules.head_constants) := by
-  apply TreeDerivation.constants_node_subset_constants_fs_union_constants_rules RegularChaseNode.out_sub_in _ node_mem
-  rw [RegularChaseNode.ingoingFacts_eq, RegularChaseNode.outgoingFacts_eq]
+  cases td.mem_iff_eq_root_or_mem_child.mp node_mem with
+  | inl node_mem => apply Set.subset_union_of_subset_left; rw [node_mem]; exact Set.subset_refl
+  | inr node_mem =>
+    rcases node_mem with ⟨_, node_mem⟩
+    exact TreeDerivation.constants_node_subset_constants_fs_union_constants_rules RegularChaseNode.out_sub_in node_mem.left node_mem.right
 
 /-- Each functional term in the chase originates as a fresh term from a trigger if it was not already part of the initial fact set. -/
 theorem functional_term_originates_from_some_trigger
@@ -1405,8 +1485,18 @@ theorem functional_term_originates_from_some_trigger
     (t_is_func : ∃ func ts arity_ok, t = GroundTerm.func func ts arity_ok)
     (t_mem : t ∈ node.node.facts.terms) :
     t ∈ td.root.facts.terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.node.origin, t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
-  apply TreeDerivation.functional_term_originates_from_some_trigger RegularChaseNode.out_sub_in _ node t_is_func t_mem
-  rw [RegularChaseNode.ingoingFacts_eq, RegularChaseNode.outgoingFacts_eq]
+  cases node.eq_root_or_mem_child with
+  | inl node_mem => apply Or.inl; simp only [node_mem, TreeDerivation.NodeWithAddress.root] at t_mem; exact t_mem
+  | inr node_mem =>
+    rcases node_mem with ⟨child, child_mem, node', node_eq⟩
+    rw [← td.root.outgoingFacts_eq]
+    cases TreeDerivation.functional_term_originates_from_some_trigger RegularChaseNode.out_sub_in (by apply TreeDerivation.NodeWithAddress.subderivation_mem_childTrees_of_mem_childNodes; exact child_mem) node' t_is_func (by rw [node'.node.ingoingFacts_eq]; rw [← node_eq] at t_mem; exact t_mem) with
+    | inl t_mem => apply Or.inl; rw [TreeDerivation.NodeWithAddress.root_subderivation'] at t_mem; exact t_mem
+    | inr t_mem =>
+      apply Or.inr; rcases t_mem with ⟨node2, prec, t_mem⟩
+      exists child.cast_for_new_root_node node2; constructor
+      . rw [← node_eq]; exact td.predecessor_of_suffix prec
+      . exact t_mem
 
 /-- If a functional term occurs in the chase, then the trigger that introduces this term must have been used in the chase, unless the term already occurs in the initial fact set. -/
 theorem trigger_introducing_functional_term_occurs_in_chase
@@ -1419,8 +1509,18 @@ theorem trigger_introducing_functional_term_occurs_in_chase
     {lt : disj_idx < trg.val.rule.head.length}
     (t_mem_trg : t ∈ trg.val.fresh_terms_for_head_disjunct disj_idx lt) :
     t ∈ td.root.facts.terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.node.origin, orig.fst.equiv trg ∧ orig.snd.val = disj_idx := by
-  apply TreeDerivation.trigger_introducing_functional_term_occurs_in_chase RegularChaseNode.out_sub_in _ node t_mem_node t_mem_trg
-  rw [RegularChaseNode.ingoingFacts_eq, RegularChaseNode.outgoingFacts_eq]
+  cases node.eq_root_or_mem_child with
+  | inl node_mem => apply Or.inl; simp only [node_mem, TreeDerivation.NodeWithAddress.root] at t_mem_node; exact t_mem_node
+  | inr node_mem =>
+    rcases node_mem with ⟨child, child_mem, node', node_eq⟩
+    rw [← td.root.outgoingFacts_eq]
+    cases TreeDerivation.trigger_introducing_functional_term_occurs_in_chase RegularChaseNode.out_sub_in (by apply TreeDerivation.NodeWithAddress.subderivation_mem_childTrees_of_mem_childNodes; exact child_mem) node' (by rw [node'.node.ingoingFacts_eq]; rw [← node_eq] at t_mem_node; exact t_mem_node) t_mem_trg with
+    | inl t_mem => apply Or.inl; rw [TreeDerivation.NodeWithAddress.root_subderivation'] at t_mem; exact t_mem
+    | inr t_mem =>
+      apply Or.inr; rcases t_mem with ⟨node2, prec, t_mem⟩
+      exists child.cast_for_new_root_node node2; constructor
+      . rw [← node_eq]; exact td.predecessor_of_suffix prec
+      . exact t_mem
 
 /-- If a functional term occurs in the chase, then the result of the trigger that introduces this term is contained in the current node, unless the functional term already occurs in the initial fact set. -/
 theorem result_of_trigger_introducing_functional_term_occurs_in_chase

--- a/ExistentialRules/ChaseSequence/TreeDerivation.lean
+++ b/ExistentialRules/ChaseSequence/TreeDerivation.lean
@@ -765,6 +765,24 @@ theorem strict_predecessor_trans {td : TreeDerivation N obs rules} {n1 n2 n3 : N
   . exact predecessor_trans prec1.left prec2.left
   . grind
 
+/-- The strict predecessor relation is transitive with respect to the regular predecessor relation. -/
+@[grind ->]
+theorem strict_prec_of_prec_of_strict_prec {td : TreeDerivation N obs rules} {n1 n2 n3 : NodeWithAddress td} :
+    n1 ≼ n2 -> n2 ≺ n3 -> n1 ≺ n3 := by
+  intro prec1 prec2
+  constructor
+  . exact predecessor_trans prec1 prec2.left
+  . cases td.eq_or_strict_of_predecessor prec1 <;> grind
+
+/-- The strict predecessor relation is transitive with respect to the regular predecessor relation. -/
+@[grind ->]
+theorem strict_prec_of_strict_prec_of_prec {td : TreeDerivation N obs rules} {n1 n2 n3 : NodeWithAddress td} :
+    n1 ≺ n2 -> n2 ≼ n3 -> n1 ≺ n3 := by
+  intro prec1 prec2
+  constructor
+  . exact predecessor_trans prec1.left prec2
+  . cases td.eq_or_strict_of_predecessor prec2 <;> grind
+
 /-- If a node is a strict predecessor, the length of its address is strictly smaller. -/
 @[grind <-]
 theorem length_address_lt_of_strict_predecessor {td : TreeDerivation N obs rules} {n1 n2 : NodeWithAddress td} :


### PR DESCRIPTION
This PR provides a proof to a theorem stating that a trigger used in the core chase can never become active again.
The result is used in the proof showing universality of the core chase result.