### PR TITLE
Define CoreChaseTrees

### DIFF
--- a/ExistentialRules/AlternativeMatches/HomomorphismExtension.lean
+++ b/ExistentialRules/AlternativeMatches/HomomorphismExtension.lean
@@ -10,7 +10,7 @@ public import ExistentialRules.AlternativeMatches.Basic
 /-!
 # Extending arbitrary Homomorphisms along a Chase Branch
 
-For some results about alternative matches, we need the ability to extend a homomorphisms from the chase node to the chase result into an endomorphism on the chase result (`ChaseBranch.hom_for_node_extendable_to_result`). We can do this in a step by step fashion along the chase. Although the result is sufficiently different, the construction, in spirit, is similar to the one used in the universality result (`chaseTreeResultIsUniversal`).
+For some results about alternative matches, we need the ability to extend a homomorphisms from the chase node to the chase result into an endomorphism on the chase result (`ChaseBranch.hom_for_node_extendable_to_result`). We can do this in a step by step fashion along the chase. Although the result is sufficiently different, the construction, in spirit, is similar to the one used in the universality result (`RegularChaseTree.universal_result`).
 -/
 
 variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
@@ -224,7 +224,7 @@ theorem hom_extends_prev_in_extend_hom_to_next_step
   rw [hom_extends_prev_in_extend_hom_to_next_step_of_next_eq_some]
   exact t_mem
 
-/-- Using `extend_hom_to_next_step` as a generator in `PossiblyInfiniteList.generate` we can create a possiblibly infinite list of homomorphisms that extend each other and all map to the result. We can combine them into a single function to have an endomorphism on the result. The idea is similar to the construction used in `chaseTreeResultIsUniversal`. -/
+/-- Using `extend_hom_to_next_step` as a generator in `PossiblyInfiniteList.generate` we can create a possiblibly infinite list of homomorphisms that extend each other and all map to the result. We can combine them into a single function to have an endomorphism on the result. The idea is similar to the construction used in `RegularChaseTree.universal_result`. -/
 public theorem hom_for_node_extendable_to_result
     {cb : RegularChaseBranch obs kb} (det : kb.rules.isDeterministic)
     {node : RegularChaseNode obs kb.rules} (node_mem : node ∈ cb.toChaseDerivation)

--- a/ExistentialRules/ChaseSequence/ChaseTree.lean
+++ b/ExistentialRules/ChaseSequence/ChaseTree.lean
@@ -79,6 +79,23 @@ theorem func_term_not_mem_root {ct : ChaseTree N obs kb}
   rw [t_eq'] at t_eq
   simp [GroundTerm.func_neq_const] at t_eq
 
+/-- A node that has an origin must be in a child tree. -/
+theorem mem_childTrees_of_isSome_origin {ct : ChaseTree N obs kb} {n : N} (n_mem : n ∈ ct) : (CN.origin n).isSome -> ∃ c ∈ ct.childTrees, n ∈ c := by
+  intro isSome_origin
+  cases ct.mem_iff_eq_root_or_mem_child.mp n_mem with
+  | inl mem => exfalso; rw [Option.isSome_iff_ne_none] at isSome_origin; apply isSome_origin; rw [mem]; exact ct.database_first'.right.right
+  | inr mem => exact mem
+
+/-- Each node that has an origin must be a child node of some other node in the tree. -/
+theorem mem_childNodes_of_some_member_of_isSome_origin {ct : ChaseTree N obs kb} (n : ct.NodeWithAddress) :
+    (CN.origin n.node).isSome -> ∃ n2 : ct.NodeWithAddress, n ∈ n2.childNodes := by
+  intro isSome_origin
+  cases n.eq_root_or_mem_child with
+  | inl mem => exfalso; rw [Option.isSome_iff_ne_none] at isSome_origin; apply isSome_origin; rw [mem]; exact ct.database_first'.right.right
+  | inr mem =>
+    rw [TreeDerivation.mem_subderivation_childNodes_iff] at mem
+    exact mem
+
 end ChaseTree
 
 /-!

--- a/ExistentialRules/ChaseSequence/CoreChase.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase.lean
@@ -8,6 +8,7 @@ module
 import ExistentialRules.ChaseSequence.CoreChase.Basic
 import ExistentialRules.ChaseSequence.CoreChase.CoreChaseBranch
 import ExistentialRules.ChaseSequence.CoreChase.CoreChaseNode
+import ExistentialRules.ChaseSequence.CoreChase.CoreChaseTree
 -- import ExistentialRules.ChaseSequence.CoreChase.TerminatesIfFinUnivModelExists
 import ExistentialRules.ChaseSequence.CoreChase.Universality
 

--- a/ExistentialRules/ChaseSequence/CoreChase/CoreChaseTree.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/CoreChaseTree.lean
@@ -1,0 +1,471 @@
+/-
+Copyright 2026 Lukas Gerlach
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+module
+
+public import ExistentialRules.ChaseSequence.ChaseTree
+public import ExistentialRules.ChaseSequence.Termination.Basic
+
+import ExistentialRules.ChaseSequence.CoreChase.Basic
+public import ExistentialRules.ChaseSequence.CoreChase.CoreChaseNode
+public import ExistentialRules.ChaseSequence.CoreChase.CoreChaseBranch
+
+/-!
+# Core Chase Trees
+
+Next to the `CoreChaseBranch` definition, we also define a tree version in line with what is done for our generic and regular chase structures.
+-/
+
+public section
+
+variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
+
+
+abbrev CoreTreeDerivation (rules : RuleSet sig) := TreeDerivation (CoreChaseNode rules) (RestrictedObsolescence sig) rules
+
+namespace CoreTreeDerivation
+
+variable {rules : RuleSet sig}
+
+section FinitenessOfFactSets
+
+/-!
+## Finiteness of FactSets in the Core Chase
+
+If we start a `CoreTreeDerivation` on a finite fact set, all other fact sets (and cores) also remain finite.
+For regular chase derivations, we only show this for `ChaseBranch`es that start on a database. However, here we also require such a result on auxiliary results that we show for the `CoreTreeDerivation`.
+-/
+
+/-- If the initial facts are finite, then the facts of every node are finite. -/
+theorem facts_finite_of_mem_of_root_finite {td : CoreTreeDerivation rules} (root_fin : td.root.facts.finite) (node : td.NodeWithAddress) : node.node.facts.finite := by
+  induction node using TreeDerivation.mem_rec_address with
+  | root => exact root_fin
+  | step new_root ih c c_mem =>
+    rw [← c.node.ingoingFacts_eq, new_root.subderivation.facts_childNodes (new_root.mem_childNodes_of_mem_childNodes c_mem), new_root.root_subderivation', new_root.node.outgoingFacts_eq]
+    apply Set.union_finite_of_both_finite (Set.finite_of_subset_finite ih new_root.node.homSubset.left)
+    apply List.finite_toSet
+
+/-- If the initial core is finite, then the cores of every node are finite. -/
+theorem core_finite_of_mem_of_root_finite {td : CoreTreeDerivation rules} (root_fin : td.root.core.finite) (node : td.NodeWithAddress) : node.node.core.finite := by
+  cases node.eq_root_or_mem_child with
+  | inl node_mem => rw [node_mem]; exact root_fin
+  | inr node_mem =>
+    rcases node_mem with ⟨c, c_mem, node', node_eq⟩
+    have inner_eq : node.node = node'.node := by rw [← node_eq]; simp [TreeDerivation.NodeWithAddress.cast_for_new_root_node]
+    rw [inner_eq]
+    apply Set.finite_of_subset_finite (facts_finite_of_mem_of_root_finite (td := c.subderivation) _ node') node'.node.homSubset.left
+    rw [c.root_subderivation',← c.node.ingoingFacts_eq]
+    rw [td.facts_childNodes (by
+      have := TreeDerivation.NodeWithAddress.mem_childNodes_of_mem_childNodes c_mem
+      rw [TreeDerivation.NodeWithAddress.subderivation_root] at this
+      exact this)]
+    rw [td.root.outgoingFacts_eq]
+    apply Set.union_finite_of_both_finite root_fin
+    apply List.finite_toSet
+
+end FinitenessOfFactSets
+
+section HomomorphismsAlongChase
+
+/-!
+## Homomorphisms along the Chase
+
+In the regular `TreeDerivation`, each steps can only add facts, which makes consecutive nodes subsets of each other.
+This is not true for the core chase. But at least, we can always find a homomorphism into the following fact sets. (This trivially holds for the regular tree derivation as well since with the subset relation the id mapping always forms such a homomorphism.)
+-/
+
+/-- For each derivation, there is a homomorphism from its root into every node. -/
+theorem exists_homomorphism_from_root_of_mem {td : CoreTreeDerivation rules} :
+    ∀ node ∈ td, ∃ h : GroundTermMapping sig, h.isHomomorphism td.root.core node.core := by
+  simp only [td.mem_iff]
+  intro node ⟨addr, node_mem⟩
+  let node' : td.NodeWithAddress := { node := node, address := addr, eq := node_mem }
+  show ∃ h : GroundTermMapping sig, h.isHomomorphism td.root.core node'.node.core
+  induction node' using td.mem_rec_address with
+  | root => exact ⟨id, GroundTermMapping.isHomomorphism_id_of_subset Set.subset_refl⟩
+  | step new_root ih c c_mem =>
+    rcases ih with ⟨h_ih, h_ih_hom⟩
+    rcases c.node.homSubset.right with ⟨h_c, h_c_hom⟩
+    have id_hom_to_c : GroundTermMapping.isHomomorphism id new_root.node.core c.node.facts := by
+      apply GroundTermMapping.isHomomorphism_id_of_subset
+      rw [← c.node.ingoingFacts_eq, new_root.subderivation.facts_childNodes (new_root.mem_childNodes_of_mem_childNodes c_mem), new_root.root_subderivation', new_root.node.outgoingFacts_eq]
+      exact Set.subset_union_of_subset_left Set.subset_refl
+    exists h_c ∘ id ∘ h_ih
+    apply GroundTermMapping.isHomomorphism_compose
+    apply GroundTermMapping.isHomomorphism_compose
+    . exact h_ih_hom
+    . exact id_hom_to_c
+    . exact h_c_hom
+
+/-- The root's core cannot occur again in the child trees. If this was the case and since we always find homomorphism from to successor cores, we can argue that then the triggers would have already been satisfied. The same theorem exists for regular `TreeDerivation`s but the argument is easier for them. -/
+theorem root_core_not_mem_childTrees_of_finite {td : CoreTreeDerivation rules} (root_finite : td.root.core.finite) :
+    ∀ c ∈ td.childTrees, ∀ node ∈ c, td.root.core ≠ node.core := by
+  intro c c_mem node node_mem contra
+  have c_root_child : c.root ∈ td.childNodes := by rw [td.childNodes_eq]; apply List.mem_map_of_mem; exact c_mem
+  let origin := c.root.origin.get (td.isSome_origin_of_mem_childNodes _ c_root_child)
+  apply c.root.origin_trg_inactive_of_isWeakCore_of_homSubset_of_finite td.root.isWeakCore _ root_finite origin (by simp [origin])
+  . exact td.active_trigger_origin_of_mem_childNodes c_root_child
+  . constructor
+    . rw [← c.root.ingoingFacts_eq, td.facts_childNodes c_root_child, td.root.outgoingFacts_eq]
+      exact Set.subset_union_of_subset_left Set.subset_refl
+    . -- there exists a homomorphism from c.root to (the second occurrence of) td.root
+      rcases exists_homomorphism_from_root_of_mem _ node_mem with ⟨h, hom⟩
+      -- we also have a homomorphism from c.root.facts to c.root.core by definition
+      rcases c.root.homSubset.right with ⟨h_core, h_core_hom⟩
+      -- we can compose both homomorphisms into a homomorphism from c.root.facts to td.root.core
+      let h_facts_root : GroundTermMapping sig := h ∘ h_core
+      have h_facts_root_hom : h_facts_root.isHomomorphism c.root.facts td.root.core := by
+        apply GroundTermMapping.isHomomorphism_compose; exact h_core_hom; rw [contra]; exact hom
+      exists h_facts_root
+
+/-- The `root` cannot occur in the `childTree`s. Otherwise, the same fact set would occur twice in the chase. But since we always find homomorphism from to successor fact sets, we can argue that then the triggers would have already been satisfied. The same theorem exists for regular `TreeDerivation`s but the argument is easier for them. -/
+theorem root_not_mem_childTrees_of_finite {td : CoreTreeDerivation rules} (root_finite : td.root.core.finite) : ¬ ∃ t ∈ td.childTrees, td.root ∈ t := by
+  intro ⟨c, c_mem, root_mem⟩
+  exact td.root_core_not_mem_childTrees_of_finite root_finite c c_mem _ root_mem rfl
+
+/-- By `root_not_mem_childTrees_of_finite`, if we have a subtree but our root occurs in the subtree, then our subtree is equal to us. -/
+@[grind ->]
+theorem eq_of_suffix_of_root_mem_of_finite {td1 td2 : CoreTreeDerivation rules}
+    (suffix : td1 <:+ td2) (root_mem : td2.root ∈ td1) (root_finite : td2.root.core.finite) : td1 = td2 := by
+  rw [td1.suffix_iff_eq_or_suffix_childTree] at suffix
+  cases suffix with
+  | inl suffix => exact suffix
+  | inr suffix => rcases suffix with ⟨td3, td3_mem, suffix⟩; apply False.elim; apply td2.root_not_mem_childTrees_of_finite root_finite; exists td3; grind
+
+end HomomorphismsAlongChase
+
+section Predecessors
+
+/-!
+## Predecessor Relation
+
+We port the predecessor results from the `TreeDerivation` that are there only shown for derivations with `RegularChaseNode`s.
+
+We also add a few results on top that are specific to the core chase such as `exists_homomorphism_of_prec` or `core_not_subset_of_strict_predecessor` (where the latter is a variant of `RegularTreeDerivation.facts_not_subset_of_strict_predecessor`.
+-/
+
+/-- For each node, there exists a homomorphism to each of its successors. -/
+theorem exists_homomorphism_of_prec {td : CoreTreeDerivation rules} {n1 n2 : td.NodeWithAddress} :
+    n1 ≼ n2 -> ∃ h : GroundTermMapping sig, h.isHomomorphism n1.node.core n2.node.core := by
+  intro ⟨diff, addr_eq⟩
+  have := exists_homomorphism_from_root_of_mem (td := n1.subderivation) n2.node
+  rw [TreeDerivation.NodeWithAddress.root_subderivation'] at this
+  apply this
+  rw [TreeDerivation.mem_iff]
+  exists diff
+  rw [← n2.eq, ← addr_eq]
+  simp [TreeDerivation.NodeWithAddress.subderivation, TreeDerivation.derivation_for_suffix]
+
+
+section StrictPredecessor
+
+/-- The node is a strict predecessor of each of its `childNodes`. -/
+theorem node_strict_prec_childNodes_of_finite {td : CoreTreeDerivation rules} (root_fin : td.root.core.finite) {node : td.NodeWithAddress} :
+    ∀ c ∈ node.childNodes, node ≺ c := by
+  intro c c_mem
+  constructor
+  . exact td.node_prec_childNodes c c_mem
+  . intro contra
+    rw [← contra] at c_mem
+    have node_fin : node.node.core.finite := by
+      apply td.core_finite_of_mem_of_root_finite
+      exact root_fin
+    apply root_not_mem_childTrees_of_finite (td := node.subderivation) (by rw [node.root_subderivation']; exact node_fin)
+    exists node.subderivation; constructor
+    . exact node.subderivation_mem_childTrees_of_mem_childNodes c_mem
+    . exact node.subderivation.root_mem
+
+/-- The core of a strict successor cannot be a subset of our core. Otherwise, our current core would not be a core. -/
+@[grind ->]
+theorem core_not_subset_of_strict_predecessor_of_finite {td : CoreTreeDerivation rules} {n1 n2 : td.NodeWithAddress} (n1_fin : n1.node.core.finite) :
+    n1 ≺ n2 -> ¬ n2.node.core ⊆ n1.node.core := by
+  intro prec contra
+  have cores_eq : n2.node.core = n1.node.core := by
+    apply FactSet.homSubset_eq_self_of_isWeakCore_of_finite _ n1.node.isWeakCore n1_fin
+    exact ⟨contra, exists_homomorphism_of_prec prec.left⟩
+  suffices ∃ c ∈ n1.childNodes, c ≼ n2 by
+    rcases this with ⟨c, c_mem, c_prec⟩
+    apply root_core_not_mem_childTrees_of_finite (td := n1.subderivation) (by rw [n1.root_subderivation']; exact n1_fin) _ (TreeDerivation.NodeWithAddress.subderivation_mem_childTrees_of_mem_childNodes c_mem) n2.node (td.mem_subderivation_of_prec c_prec)
+    rw [cores_eq]; simp
+  exists td.next_on_path_to_succ prec; constructor
+  . exact td.next_on_path_to_succ_mem_childNodes prec
+  . exact td.next_on_path_to_succ_is_prec prec
+
+end StrictPredecessor
+
+end Predecessors
+
+section TermsInChase
+
+/-!
+## Terms in the Chase
+
+We make some general observations about certain terms that might occur in the chase.
+
+1. Constants can only originate directly from rules or from the initial fact set. No other constants can be introduced.
+2. Functional terms can either also originate from the initial fact set or they are introduced as fresh terms by a trigger.
+
+The second observation entails that the precense of a functional term that does not occur in the initial fact set implies
+that the trigger that introduces this term must have been applied in some `ChaseNode`.
+-/
+
+
+/-- Constants in the chase can only come from the initial fact set or from a constant in a rule. -/
+theorem constants_node_subset_constants_fs_union_constants_rules
+    {td child : CoreTreeDerivation rules}
+    (child_mem : child ∈ td.childTrees)
+    {node : CoreChaseNode rules} (node_mem : node ∈ child) :
+    node.facts.constants ⊆ td.root.core.constants ∪ rules.head_constants :=
+  TreeDerivation.constants_node_subset_constants_fs_union_constants_rules CoreChaseNode.out_sub_in child_mem node_mem
+
+/-- Each functional term in the chase originates as a fresh term from a trigger if it was not already part of the initial fact set. -/
+theorem functional_term_originates_from_some_trigger
+    {td child : CoreTreeDerivation rules}
+    (child_mem : child ∈ td.childTrees)
+    (node : child.NodeWithAddress)
+    {t : GroundTerm sig}
+    (t_is_func : ∃ func ts arity_ok, t = GroundTerm.func func ts arity_ok)
+    (t_mem : t ∈ node.node.facts.terms) :
+    t ∈ td.root.core.terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.node.origin, t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) :=
+  TreeDerivation.functional_term_originates_from_some_trigger CoreChaseNode.out_sub_in child_mem node t_is_func t_mem
+
+/-- If a functional term occurs in the chase, then the trigger that introduces this term must have been used in the chase, unless the term already occurs in the initial fact set. -/
+theorem trigger_introducing_functional_term_occurs_in_chase
+    {td child : CoreTreeDerivation rules}
+    (child_mem : child ∈ td.childTrees)
+    (node : child.NodeWithAddress)
+    {t : GroundTerm sig}
+    (t_mem_node : t ∈ node.node.facts.terms)
+    {trg : RTrigger (RestrictedObsolescence sig) rules}
+    {disj_idx : Nat}
+    {lt : disj_idx < trg.val.rule.head.length}
+    (t_mem_trg : t ∈ trg.val.fresh_terms_for_head_disjunct disj_idx lt) :
+    t ∈ td.root.core.terms ∨ ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.node.origin, orig.fst.equiv trg ∧ orig.snd.val = disj_idx :=
+  TreeDerivation.trigger_introducing_functional_term_occurs_in_chase CoreChaseNode.out_sub_in child_mem node t_mem_node t_mem_trg
+
+end TermsInChase
+
+section Result
+
+/-!
+## Core Chase Result
+
+Oppossed to regular tree derivations, the result of a core tree derivation is only defined if the derivation terminates. Then it is simply the last element.
+Just like for RegularTreeDerivations however, the result also models all rules.
+-/
+
+abbrev result (td : CoreTreeDerivation rules) (term : td.terminates) : Set (FactSet sig) :=
+  -- We do not use `Set.map` since we currently do not have `Set.attach`. Maybe we should introduce this...
+  fun fs => ∃ (deriv : CoreChaseDerivation rules) (mem : deriv ∈ td.branches), deriv.result (term _ mem) = fs
+
+/--
+Since the result is only defined for terminating trees, it must be finite
+(which does not mean that each individual fact set is finite as well, this would only hold for proper `CoreChaseTree`s).
+-/
+theorem result_finite {td : CoreTreeDerivation rules} (term : td.terminates) : (td.result term).finite := by
+  rcases td.branches_finite_of_terminates term with ⟨branches, _, eq⟩
+  have : DecidableEq (FactSet sig) := Classical.typeDecidableEq (FactSet sig)
+  apply Set.finite_of_list_with_same_elements
+    (branches.attach.map (fun d => CoreChaseDerivation.result d.val (by apply term d.val; rw [← eq]; exact d.property)))
+  intro fs; rw [List.mem_map]
+  constructor
+  . intro ⟨d, _, fs_eq⟩; exists d.val, (by rw [← eq]; exact d.property)
+  . intro ⟨d, mem, fs_eq⟩; exists ⟨d, by rw [eq]; exact mem⟩; simpa
+
+/-- Each element of the `result` models the rules. -/
+theorem result_models_rules {td : CoreTreeDerivation rules} (term : td.terminates) : ∀ fs ∈ td.result term, fs.modelsRules rules := by
+  intro fs ⟨d, d_mem, fs_eq⟩; rw [← fs_eq]; exact d.result_models_rules (term _ d_mem)
+
+end Result
+
+end CoreTreeDerivation
+
+
+abbrev CoreChaseTree (kb : KnowledgeBase sig) := ChaseTree (CoreChaseNode kb.rules) (RestrictedObsolescence sig) kb
+
+namespace CoreChaseTree
+
+variable {kb : KnowledgeBase sig}
+
+section FinitenessOfFactSets
+
+/-!
+## Finiteness of FactSets in the Core Chase
+
+Just as in a regular `ChaseTree`, every fact set (and every core) that occurs in the `CoreChaseTree` is finite simply since the (initial) database is finite and since each step only adds finitely many facts.
+-/
+
+/- Each fact set in the chase is finite. -/
+theorem facts_finite_of_mem {ct : CoreChaseTree kb} (node : ct.NodeWithAddress) : node.node.facts.finite := by
+  apply CoreTreeDerivation.facts_finite_of_mem_of_root_finite
+  rw [← ct.root.ingoingFacts_eq, ct.database_first'.left]; exact kb.db.toFactSet.property.left
+
+/- Each core in the chase is finite. -/
+theorem core_finite_of_mem {ct : CoreChaseTree kb} (node : ct.NodeWithAddress) : node.node.core.finite := by
+  apply Set.finite_of_subset_finite (ct.facts_finite_of_mem node) node.node.homSubset.left
+
+end FinitenessOfFactSets
+
+section DatabaseContainment
+
+/-!
+## Database Containment
+
+Even though we do not have fact set monotonicity in the core chase, it is still true that the database occurs in every fact set and core in the chase.
+This is because the database only features constants and these can never be remapped by any homomorphism.
+We also have a result here stating that every member of the `CoreChaseTree` result is a model.
+-/
+
+/-- The database is a subset of each node since the database only contains constants which can never be remapped by homomorphisms. -/
+theorem db_mem_of_mem {ct : CoreChaseTree kb} : ∀ (node : ct.NodeWithAddress), kb.db.toFactSet.val ⊆ node.node.core := by
+  intro node
+  rcases CoreTreeDerivation.exists_homomorphism_from_root_of_mem _ node.mem with ⟨h, hom⟩
+  intro f f_mem
+  apply hom.right
+  rw [← CoreChaseNode.outgoingFacts_eq, ct.database_first'.right.left]
+  rw [GroundTermMapping.mem_applyFactSet]; exists f; constructor; exact f_mem
+  apply Eq.symm; apply h.applyFact_eq_self_of_isIdOnConstants_of_isFunctionFree
+  . exact hom.left
+  . exact kb.db.toFactSet.property.right f f_mem
+
+/-- Each result member of a `CoreChaseTree` models the whole `KnowledgeBase`. -/
+theorem result_models_kb {ct : CoreChaseTree kb} (term : ct.terminates) : ∀ fs ∈ CoreTreeDerivation.result ct.toTreeDerivation term, fs.modelsKb kb := by
+  intro fs ⟨branch, branch_mem, fs_mem⟩
+  let cb := ct.chaseBranch_for_branch branch_mem
+  have cb_mem : cb.toChaseDerivation ∈ ct.branches := by simpa [cb, ChaseTree.chaseBranch_for_branch] using branch_mem
+  have : CoreChaseDerivation.result branch (term _ branch_mem) = CoreChaseDerivation.result cb.toChaseDerivation (term _ cb_mem) := by rfl
+  simp only [← fs_mem, this]
+  exact CoreChaseBranch.result_models_kb (term _ cb_mem)
+
+end DatabaseContainment
+
+section Predecessors
+
+/-!
+## Predecessor Relation
+
+Compared to the `CoreChaseDerivation`, we can now drop the explicit finiteness conditions.
+-/
+
+section StrictPredecessor
+
+/-- The node is a strict predecessor of each of its `childNodes`. -/
+theorem node_strict_prec_childNodes {ct : CoreChaseTree kb} {node : ct.NodeWithAddress} :
+    ∀ c ∈ node.childNodes, node ≺ c := by
+  apply CoreTreeDerivation.node_strict_prec_childNodes_of_finite; exact core_finite_of_mem (TreeDerivation.NodeWithAddress.root ct.toTreeDerivation)
+
+/-- The core of a strict successor cannot be a subset of our core. Otherwise, our current core would not be a core. -/
+@[grind ->]
+theorem core_not_subset_of_strict_predecessor {ct : CoreChaseTree kb} {n1 n2 : ct.NodeWithAddress} : n1 ≺ n2 -> ¬ n2.node.core ⊆ n1.node.core := by
+  apply CoreTreeDerivation.core_not_subset_of_strict_predecessor_of_finite; apply core_finite_of_mem
+
+end StrictPredecessor
+
+end Predecessors
+
+section TermsInChase
+
+/-!
+## Terms in the Chase
+
+We make some general observations about certain terms that might occur in the chase.
+
+1. Constants can only originate directly from rules or from the initial fact set. No other constants can be introduced.
+2. Functional terms can either also originate from the initial fact set or they are introduced as fresh terms by a trigger.
+
+The second observation entails that the precense of a functional term that does not occur in the initial fact set implies
+that the trigger that introduces this term must have been applied in some `ChaseNode`.
+-/
+
+/-- Constants in the chase must be in the database or in some rule. -/
+theorem constants_node_subset_constants_db_union_constants_rules
+    {ct : CoreChaseTree kb}
+    {node : CoreChaseNode kb.rules} (node_mem : node ∈ ct) :
+    node.facts.constants ⊆ (kb.db.constants.val ∪ kb.rules.head_constants) := by
+  cases ct.mem_iff_eq_root_or_mem_child.mp node_mem with
+  | inl node_mem => apply Set.subset_union_of_subset_left; rw [node_mem, ← ct.root.ingoingFacts_eq, ct.database_first'.left, Database.toFactSet_constants_same]; exact Set.subset_refl
+  | inr node_mem =>
+    rcases node_mem with ⟨_, node_mem⟩
+    rw [← Database.toFactSet_constants_same, ← ct.database_first'.right.left, ct.root.outgoingFacts_eq]
+    exact CoreTreeDerivation.constants_node_subset_constants_fs_union_constants_rules node_mem.left node_mem.right
+
+/-- Each functional term in the chase originates as a fresh term from a trigger. -/
+theorem functional_term_originates_from_some_trigger
+    {ct : CoreChaseTree kb}
+    (node : ct.NodeWithAddress)
+    {t : GroundTerm sig}
+    (t_is_func : ∃ func ts arity_ok, t = GroundTerm.func func ts arity_ok)
+    (t_mem : t ∈ node.node.facts.terms) :
+    ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.node.origin,
+      t ∈ orig.fst.val.fresh_terms_for_head_disjunct orig.snd.val (by rw [← PreTrigger.length_mapped_head]; exact orig.snd.isLt) := by
+  have t_nmem_root : t ∉ ct.root.core.terms := by
+    intro t_mem
+    exact ct.func_term_not_mem_root t_is_func t_mem
+  cases node.eq_root_or_mem_child with
+  | inl node_mem =>
+    simp only [TreeDerivation.NodeWithAddress.root] at node_mem
+    rw [node_mem, ← ct.root.ingoingFacts_eq, ct.database_first'.left, ← ct.database_first'.right.left] at t_mem
+    apply False.elim; apply t_nmem_root; exact t_mem
+  | inr node_mem =>
+    rcases node_mem with ⟨child, child_mem, node', node_eq⟩
+    cases CoreTreeDerivation.functional_term_originates_from_some_trigger (by apply TreeDerivation.NodeWithAddress.subderivation_mem_childTrees_of_mem_childNodes; exact child_mem) node' t_is_func (by rw [← node_eq] at t_mem; exact t_mem)  with
+    | inl t_mem => apply False.elim; rw [TreeDerivation.NodeWithAddress.subderivation_root] at t_mem; exact t_nmem_root t_mem
+    | inr t_mem =>
+      rcases t_mem with ⟨node2, prec, t_mem⟩
+      exists child.cast_for_new_root_node node2; constructor
+      . rw [← node_eq]; exact ct.predecessor_of_suffix prec
+      . exact t_mem
+
+/-- If a functional term occurs in the chase, then the trigger that introduces this term must have been used in the chase. -/
+theorem trigger_introducing_functional_term_occurs_in_chase
+    {ct : CoreChaseTree kb}
+    (node : ct.NodeWithAddress)
+    {t : GroundTerm sig}
+    (t_mem_node : t ∈ node.node.facts.terms)
+    {trg : RTrigger (RestrictedObsolescence sig) kb.rules}
+    {disj_idx : Nat}
+    {lt : disj_idx < trg.val.rule.head.length}
+    (t_mem_trg : t ∈ trg.val.fresh_terms_for_head_disjunct disj_idx lt) :
+    ∃ node2, node2 ≼ node ∧ ∃ orig ∈ node2.node.origin, orig.fst.equiv trg ∧ orig.snd.val = disj_idx := by
+  have t_nmem_root : t ∉ ct.root.core.terms := by
+    intro t_mem
+    exact ct.func_term_not_mem_root (PreTrigger.term_functional_of_mem_fresh_terms _ t_mem_trg) t_mem
+  cases node.eq_root_or_mem_child with
+  | inl node_mem =>
+    simp only [TreeDerivation.NodeWithAddress.root] at node_mem
+    rw [node_mem, ← ct.root.ingoingFacts_eq, ct.database_first'.left, ← ct.database_first'.right.left] at t_mem_node
+    apply False.elim; apply t_nmem_root; exact t_mem_node
+  | inr node_mem =>
+    rcases node_mem with ⟨child, child_mem, node', node_eq⟩
+    cases CoreTreeDerivation.trigger_introducing_functional_term_occurs_in_chase (by apply TreeDerivation.NodeWithAddress.subderivation_mem_childTrees_of_mem_childNodes; exact child_mem) node' (by rw [← node_eq] at t_mem_node; exact t_mem_node) t_mem_trg with
+    | inl t_mem => apply False.elim; rw [TreeDerivation.NodeWithAddress.subderivation_root] at t_mem; exact t_nmem_root t_mem
+    | inr t_mem =>
+      rcases t_mem with ⟨node2, prec, t_mem⟩
+      exists child.cast_for_new_root_node node2; constructor
+      . rw [← node_eq]; exact ct.predecessor_of_suffix prec
+      . exact t_mem
+
+end TermsInChase
+
+section OriginTriggerRemainsInactive
+
+/-!
+## Used triggers remain inactive
+
+Here we prove that triggers used in the core chase remain inactive from this point.
+Not only that but also every equivalent trigger (producing the same result) is inactive from this point on.
+For regular chase trees this is trivial because of fact monotonicity but here it is not quite obvious (even though it's intuitive).
+-/
+
+theorem origin_trg_remains_inactive {ct : CoreChaseTree kb} {n1 n2 : ct.NodeWithAddress} (prec : n1 ≼ n2) :
+    ∀ orig ∈ n1.node.origin, ∀ trg, orig.fst.equiv trg -> ¬ trg.val.active n2.node.core := by
+  -- We assume for a contradiction that trg is active on n2 (captured in contra).
+  intro orig orig_mem trg equiv contra
+  sorry
+
+end OriginTriggerRemainsInactive
+
+end CoreChaseTree
+

--- a/ExistentialRules/ChaseSequence/CoreChase/CoreChaseTree.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/CoreChaseTree.lean
@@ -463,7 +463,181 @@ theorem origin_trg_remains_inactive {ct : CoreChaseTree kb} {n1 n2 : ct.NodeWith
     ∀ orig ∈ n1.node.origin, ∀ trg, orig.fst.equiv trg -> ¬ trg.val.active n2.node.core := by
   -- We assume for a contradiction that trg is active on n2 (captured in contra).
   intro orig orig_mem trg equiv contra
-  sorry
+  cases ct.eq_or_strict_of_predecessor prec with
+  | inl eq =>
+    -- We have shown the base case (n1 = n2) in a separate result on `CoreChaseNode`.
+    apply n1.node.equiv_origin_trg_inactive_for_own_core_of_finite (ct.core_finite_of_mem n1) _ orig_mem _ equiv
+    rw [eq]
+    exact contra
+  | inr prec =>
+    -- We get the node that is just before n1 and show some of its essential properties.
+    rcases ct.mem_childNodes_of_some_member_of_isSome_origin n1 (by simp only [ChaseNode.origin]; rw [orig_mem]; simp) with ⟨just_before_n1, n1_child⟩
+    have just_before_n1_prec : just_before_n1 ≺ n1 := ct.node_strict_prec_childNodes _ n1_child
+    have orig_active_just_before_n1 : orig.fst.val.active just_before_n1.node.core := by
+      have active := just_before_n1.subderivation.active_trigger_origin_of_mem_childNodes (just_before_n1.mem_childNodes_of_mem_childNodes n1_child)
+      rw [Option.mem_def] at orig_mem
+      simp only [ChaseNode.origin, orig_mem, Option.get_some] at active
+      rw [just_before_n1.root_subderivation'] at active
+      apply active
+    -- We also get the node that is just before n2 and show some of its essential properties.
+    rcases ct.mem_childNodes_of_some_node_of_strict_prec prec with ⟨just_before_n2, just_before_n2_succ, n2_child⟩
+    -- The following is used in the proof but also required to prove termination of the recursive theorem.
+    have just_before_n2_prec : just_before_n2 ≺ n2 := ct.node_strict_prec_childNodes _ n2_child
+    -- From a recursive call to the theorem, we get that no equivalent trigger can be active on just_before_n2.
+    have no_trg_active_head_cd2 : ∀ trg, orig.fst.equiv trg -> ¬ trg.val.active just_before_n2.node.core := origin_trg_remains_inactive just_before_n2_succ _ orig_mem
+    -- If however there is an equivalent trigger loaded just_before_n2, then we can quickly conclude the proof
+    -- by showing that this trigger would then in fact be active on just_before_n2, which is a contradiction.
+    -- Or rather: if it was not active, then we can show that trg is obsolete on n2,
+    -- but this contradicts our assumption made in the beginning.
+    cases Classical.em (∃ trg, orig.fst.equiv trg ∧ trg.val.loaded just_before_n2.node.core) with
+    | inl ex_loaded_trg =>
+      rcases ex_loaded_trg with ⟨loaded_trg, loaded_trg_equiv, loaded_trg_loaded⟩
+      apply no_trg_active_head_cd2 loaded_trg loaded_trg_equiv
+      constructor; exact loaded_trg_loaded; intro loaded_trg_obs
+      apply contra.right
+      apply equiv_trg_obsolete_of_isWeakCore_of_homSubset_of_finite n2.node.isWeakCore n2.node.homSubset (ct.core_finite_of_mem n2) _ _ _ (PreTrigger.equiv_trans (PreTrigger.equiv_symm loaded_trg_equiv) equiv) contra.left
+      apply PreTrigger.satisfied_of_satisfied_subset _ loaded_trg_obs
+      rw [← n2.node.ingoingFacts_eq, just_before_n2.subderivation.facts_childNodes (just_before_n2.mem_childNodes_of_mem_childNodes n2_child)]
+      apply Set.subset_union_of_subset_left
+      rw [just_before_n2.root_subderivation', just_before_n2.node.outgoingFacts_eq]
+      exact Set.subset_refl
+    | inr ex_loaded_trg =>
+      -- If no equivalent trigger is loaded just_before_n2, things get more complicated...
+      -- First, we obtain the first node after n1, where no equivalent trigger is loaded; call that n3.
+      let target_prop (node : ct.NodeWithAddress) : Prop :=
+        n1 ≼ node ∧ ¬ ∃ trg, orig.fst.equiv trg ∧ trg.val.loaded node.node.core
+      rcases ct.prop_for_node_has_minimal_such_node target_prop just_before_n2 ⟨just_before_n2_succ, ex_loaded_trg⟩ with ⟨n3, ⟨n3_prec, none_loaded_n3⟩, n3_prec_just_before_n2, n3_minimal⟩
+      -- Now let's assume for a second that we can find a frontier term that is not part of n3's core.
+      suffices ∃ v ∈ trg.val.rule.frontier, trg.val.subs v ∉ n3.node.core.terms by
+        -- We know a couple things about such a term:
+        -- 1. it must occur in just_before_n1 and n2 because the equivalent triggers are loaded there, and
+        -- 2. it must be a functional term since constants can never be removed.
+        rcases this with ⟨v, v_mem, t_nmem⟩
+        have t_mem_core_cd_where_n1_next : trg.val.subs v ∈ just_before_n1.node.core.terms := by
+          apply FactSet.terms_subset_of_subset orig_active_just_before_n1.left
+          rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]; apply Or.inr
+          exists v; constructor
+          . apply Rule.frontier_subset_vars_body; rw [equiv.left]; exact v_mem
+          . apply equiv.right; rw [equiv.left]; exact v_mem
+        have t_mem_facts_cd_where_n1_next : trg.val.subs v ∈ just_before_n1.node.facts.terms := by
+          apply FactSet.terms_subset_of_subset just_before_n1.node.homSubset.left
+          exact t_mem_core_cd_where_n1_next
+        have t_mem_facts_n2 : trg.val.subs v ∈ n2.node.facts.terms := by
+          apply FactSet.terms_subset_of_subset (Set.subset_trans contra.left n2.node.homSubset.left)
+          rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]; apply Or.inr
+          exists v; constructor
+          . apply Rule.frontier_subset_vars_body; exact v_mem
+          . rfl
+        have t_func : ∃ func ts arity_ok, trg.val.subs v = .func func ts arity_ok := by
+          cases eq : trg.val.subs v with
+          | func func ts arity_ok => exists func, ts, arity_ok
+          | const c =>
+            exfalso
+            apply t_nmem
+            rcases CoreTreeDerivation.exists_homomorphism_of_prec (ct.predecessor_trans just_before_n1_prec.left n3_prec) with ⟨h, hom⟩
+            suffices h (trg.val.subs v) ∈ n3.node.core.terms by
+              rw [eq]; rw [eq, hom.left] at this; exact this
+            apply FactSet.terms_subset_of_subset hom.right
+            rw [h.terms_applyFactSet]
+            apply Set.mem_map_of_mem
+            exact t_mem_core_cd_where_n1_next
+        -- We also know that n3 strictly occurs before n2 (because it occurs before just_before_n2).
+        -- The argument is a bit more elaborate then one might think.
+        have n3_prec_n2 : n3 ≺ n2 := ct.strict_prec_of_prec_of_strict_prec n3_prec_just_before_n2 just_before_n2_prec
+        -- Since the frontier term in question occurs in just_before_n1,
+        -- it must have been introduced by a trigger before.
+        rcases ct.functional_term_originates_from_some_trigger just_before_n1 t_func t_mem_facts_cd_where_n1_next with ⟨t_orig_node_before_n1, t_orig_node_before_n1_prec, t_orig_before_n1, t_orig_before_n1_mem, t_mem_orig_before_n1⟩
+
+        rcases ct.predecessor_iff.mp (ct.next_on_path_to_succ_is_prec n3_prec_n2) with ⟨n2', n2_eq⟩
+
+        cases CoreTreeDerivation.trigger_introducing_functional_term_occurs_in_chase (td := n3.subderivation)
+          (n3.subderivation_mem_childTrees_of_mem_childNodes (ct.next_on_path_to_succ_mem_childNodes n3_prec_n2))
+          n2'
+          (by rw [← n2_eq] at t_mem_facts_n2; exact t_mem_facts_n2)
+          t_mem_orig_before_n1 with
+        | inl contra => apply t_nmem; rw [n3.root_subderivation'] at contra; exact contra
+        | inr trg_occurs_again =>
+          -- Now for the rest of this subproof we just apply our theorem recursively to conclude
+          -- the proof as we now found two nodes where a trigger is applied twice (up to equivalence).
+          -- The recursive call is fine since the first occurrence is before n1, so the first node is decreasing.
+          rcases trg_occurs_again with ⟨t_orig_node_after_n3, t_orig_node_after_n3_prec, t_orig_after_n3, t_orig_after_n3_mem, t_orig_trgs_equiv, t_mem_orig_after_n3⟩
+
+          have t_orig_node_after_n3_succ : n3 ≺ TreeDerivation.NodeWithAddress.cast_for_new_root_node _ t_orig_node_after_n3 := by
+            apply ct.strict_prec_of_strict_prec_of_prec (ct.node_strict_prec_childNodes _ (ct.next_on_path_to_succ_mem_childNodes n3_prec_n2))
+            apply List.prefix_append
+          rcases ct.mem_childNodes_of_some_node_of_strict_prec t_orig_node_after_n3_succ with ⟨just_before_t_orig_node, just_before_t_orig_node_succ, t_orig_node_child⟩
+          have t_orig_nodes_prec : t_orig_node_before_n1 ≼ just_before_t_orig_node := by
+            apply ct.predecessor_trans t_orig_node_before_n1_prec
+            apply ct.predecessor_trans just_before_n1_prec.left
+            apply ct.predecessor_trans n3_prec
+            exact just_before_t_orig_node_succ
+          have _term : t_orig_node_before_n1 ≺ n1 := by
+            exact ct.strict_prec_of_prec_of_strict_prec t_orig_node_before_n1_prec just_before_n1_prec
+          apply origin_trg_remains_inactive t_orig_nodes_prec _ t_orig_before_n1_mem _ (PreTrigger.equiv_symm t_orig_trgs_equiv)
+          suffices t_orig_after_n3 = t_orig_node_after_n3.node.origin.get (just_before_t_orig_node.subderivation.isSome_origin_of_mem_childNodes _ (just_before_t_orig_node.mem_childNodes_of_mem_childNodes t_orig_node_child)) by
+            rw [this];
+            have active := just_before_t_orig_node.subderivation.active_trigger_origin_of_mem_childNodes (just_before_t_orig_node.mem_childNodes_of_mem_childNodes t_orig_node_child)
+            rw [just_before_t_orig_node.root_subderivation'] at active
+            exact active
+          rw [Option.mem_def] at t_orig_after_n3_mem
+          simp [t_orig_after_n3_mem]
+
+      -- It remains to be shown now that indeed some frontier term cannot be part of n3's core.
+      -- First, we prove that on n3's facts, some equivalent trigger is still loaded
+      -- (meaning that all frontier terms must still be there).
+      -- This means that n3 is the exact node where the frontier term gets removed when taking the core.
+      have prop_still_true_on_n3_facts : ∃ trg, orig.fst.equiv trg ∧ trg.val.loaded n3.node.facts := by
+        cases ct.eq_or_strict_of_predecessor n3_prec with
+        | inl eq =>
+          exists orig.fst; constructor; exact PreTrigger.equiv_refl
+          rw [← eq]
+          apply Set.subset_trans orig_active_just_before_n1.left
+          rw [← n1.node.ingoingFacts_eq, just_before_n1.subderivation.facts_childNodes (just_before_n1.mem_childNodes_of_mem_childNodes n1_child)]
+          apply Set.subset_union_of_subset_left
+          rw [just_before_n1.root_subderivation']
+          exact Set.subset_refl
+        | inr prec =>
+          rcases ct.mem_childNodes_of_some_node_of_strict_prec prec with ⟨just_before_n3, just_before_n3_succ, n3_child⟩
+          specialize n3_minimal just_before_n3 (ct.node_strict_prec_childNodes _ n3_child)
+          unfold target_prop at n3_minimal
+          simp only [not_and, Classical.not_not] at n3_minimal
+          rcases n3_minimal just_before_n3_succ with ⟨trg, equiv, loaded⟩
+          exists trg; constructor; exact equiv
+          rw [← n3.node.ingoingFacts_eq, just_before_n3.subderivation.facts_childNodes (just_before_n3.mem_childNodes_of_mem_childNodes n3_child)]
+          apply Set.subset_union_of_subset_left
+          rw [just_before_n3.root_subderivation']
+          exact loaded
+
+      -- Now let's assume for a contradiction that all frontier terms are still part of n3's core.
+      -- The idea for the rest of the proof is the following:
+      -- There is a homomorphism from n3's facts to its core. If all frontier terms still occur in the core, then we can repeat this homomorphism to just be the identity on these terms. But then this repeated homomorphism can be used to build an equivalent trigger that is loaded on n3's core, which yields the desired contradiction.
+      apply Classical.byContradiction
+      simp only [not_exists, not_and, Classical.not_not]
+      intro frontier_still_occurs
+      apply none_loaded_n3
+      rcases prop_still_true_on_n3_facts with ⟨trg', equiv', loaded'⟩
+
+      rcases ex_hom_that_is_id_on_terms_of_isWeakCore_of_homSubset_of_finite n3.node.isWeakCore n3.node.homSubset (ct.core_finite_of_mem n3)
+        with ⟨h, hom, id_on_terms⟩
+      let target_trg : Trigger (RestrictedObsolescence sig) := { rule := trg'.val.rule, subs := h ∘ trg'.val.subs}
+      exists ⟨target_trg, trg'.property⟩; constructor
+      . constructor
+        . rw [equiv'.left]
+        . intro v v_mem
+          rw [equiv'.right _ v_mem]
+          simp only [target_trg, Function.comp_apply]
+          rw [id_on_terms]
+          suffices trg'.val.subs v = trg.val.subs v by
+            rw [this]; apply frontier_still_occurs; rw [← equiv.left]; exact v_mem
+          rw [← equiv'.right _ v_mem, equiv.right _ v_mem]
+      . simp only [PreTrigger.loaded, PreTrigger.mapped_body]
+        rw [GroundSubstitution.apply_function_free_conj_compose_of_isIdOnConstants _ _ hom.left]
+        apply Set.subset_trans _ hom.right
+        rw [Function.comp_apply]
+        rw [← TermMapping.apply_generalized_atom_set_toSet]
+        apply TermMapping.apply_generalized_atom_set_subset_of_subset
+        exact loaded'
+termination_by (n1, n2)
 
 end OriginTriggerRemainsInactive
 

--- a/ExistentialRules/ChaseSequence/CoreChase/Universality.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/Universality.lean
@@ -5,188 +5,144 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 module
 
+public import ExistentialRules.ChaseSequence.Deterministic
+import ExistentialRules.ChaseSequence.Universality
+
 import ExistentialRules.ChaseSequence.CoreChase.Basic
 public import ExistentialRules.ChaseSequence.CoreChase.CoreChaseBranch
+public import ExistentialRules.ChaseSequence.CoreChase.CoreChaseTree
 
 /-!
 # Universality of the Core Chase Result
 
-Just as for determistic `RegularChaseBranch`es, the result of a determistic `CoreChaseBranch` is a universal model of the underlying `KnowledgeBase`.
+Just as for `RegularChaseTree`s, the result of a `CoreChaseTree` is a universal model set of the underlying `KnowledgeBase`.
+Also, for determistic `CoreChaseBranch`es, result is a universal model.
 -/
 
+public section
+
 variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
+
+section CoreChaseTreeUniversality
+
+namespace CoreChaseTree
+
+variable {kb : KnowledgeBase sig}
+
+open AuxiliaryDefsAndTheoremsForUniversalityProof
+
+theorem universal_result (ct : CoreChaseTree kb) (terminates : ct.terminates) : ∀ (m : FactSet sig), m.modelsKb kb ->
+    ∃ (fs : FactSet sig) (h : GroundTermMapping sig), fs ∈ CoreTreeDerivation.result ct.toTreeDerivation terminates ∧ h.isHomomorphism fs m := by
+
+  have trg_inactive_of_fresh_term_present : ∀ (node : ct.NodeWithAddress) (trg : RTrigger (RestrictedObsolescence sig) kb.rules) i lt t, t ∈ trg.val.fresh_terms_for_head_disjunct i lt -> t ∈ (CoreChaseNode.coreChaseNodeInstance.outgoingFacts node.node).terms -> ¬ trg.val.active (CoreChaseNode.coreChaseNodeInstance.outgoingFacts node.node) := by
+    intro node trg i lt t t_fresh t_mem_node trg_act
+    rw [node.node.outgoingFacts_eq] at t_mem_node
+    rw [node.node.outgoingFacts_eq] at trg_act
+    rcases ct.trigger_introducing_functional_term_occurs_in_chase node (FactSet.terms_subset_of_subset node.node.homSubset.left _ t_mem_node) t_fresh
+      with ⟨node2, node2_prec, orig, orig_mem, orig_equiv, head_idx_eq⟩
+    exact ct.origin_trg_remains_inactive node2_prec _ orig_mem _ orig_equiv trg_act
+
+  intro m m_is_model
+
+  let derivs_with_homs := infinite_list_of_derivations_and_homomorphisms CoreChaseNode.out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present
+  let deriv := (head_infinite_list_of_derivations_and_homomorphisms CoreChaseNode.out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present).fst
+  let branch := ct.chaseBranch_for_branch (branch := deriv) mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms
+
+  let target_idx := (deriv.branch.toList_of_finite (terminates _ mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms)).length - 1
+  suffices (derivs_with_homs.get? target_idx).map (fun step => step.fst.head.core) = some (CoreChaseDerivation.result branch.toChaseDerivation (terminates _ mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms)) by
+    have isSome : (derivs_with_homs.get? target_idx).isSome := by
+      rw [Option.map_eq_some_iff] at this; rcases this with ⟨_, eq, _⟩; simp [eq]
+    let step := (derivs_with_homs.get? target_idx).get isSome
+    have step_eq_result : step.fst.head.core = CoreChaseDerivation.result branch.toChaseDerivation (terminates _ mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms) := by
+      rw [← Option.some_get isSome, Option.map_some, Option.some_inj] at this; exact this
+    exists CoreChaseDerivation.result branch.toChaseDerivation (terminates _ mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms)
+    exists step.snd
+    constructor
+    . exists deriv, mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms
+    . rw [← step_eq_result]
+      apply each_step_isHomomorphism_in_infinite_list_of_derivations_and_homomorphisms
+      rw [derivs_with_homs.mem_iff]
+      exists target_idx
+      simp [step]
+  simp only [CoreChaseDerivation.result, ChaseDerivationSkeleton.last]
+  rw [List.getLast_eq_getElem, ← Option.map_some, ← List.getElem?_eq_getElem]
+  rw [PossiblyInfiniteList.getElem?_toList_of_finite]
+  simp only [branch, ChaseTree.chaseBranch_for_branch]
+  simp only [deriv, fst_head_infinite_list_of_derivations_and_homomorphisms_eq_list_of_all_heads]
+  rw [PossiblyInfiniteList.get?_map, Option.map_map]
+  congr
+  simp only [← fst_head_infinite_list_of_derivations_and_homomorphisms_eq_list_of_all_heads]; rfl
+
+end CoreChaseTree
+
+end CoreChaseTreeUniversality
+
+
+section CoreChaseDeterministic
+
+namespace CoreTreeDerivation
+
+variable {rules : RuleSet sig}
+
+/-- The `firstResult` is the result of the `firstBranch`. -/
+def firstResult (td : CoreTreeDerivation rules) (terminates : td.terminates) : FactSet sig := CoreChaseDerivation.result td.firstBranch (terminates _ td.firstBranch_mem_branches)
+
+/-- The `firstResult` is a member of the `TreeDerivation.result`. -/
+theorem firstResult_mem_result {td : CoreTreeDerivation rules} {terminates : td.terminates} : td.firstResult terminates ∈ td.result terminates := by
+  unfold CoreTreeDerivation.result
+  exists td.firstBranch; constructor
+  . rfl
+  . exact td.firstBranch_mem_branches
+
+end CoreTreeDerivation
+
+namespace CoreChaseTree
+
+variable {kb : KnowledgeBase sig}
+
+/-- In the deterministic setting, the `firstResult` of a `CoreChaseTree` is by itself a universal model. -/
+theorem deterministicChaseTreeResultUniversallyModelsKb {ct : CoreChaseTree kb} (det : kb.isDeterministic) (terminates : ct.terminates) :
+    (CoreTreeDerivation.firstResult ct.toTreeDerivation terminates).universallyModelsKb kb := by
+  constructor
+  . apply ct.result_models_kb; exact CoreTreeDerivation.firstResult_mem_result
+  . intro m m_is_model
+    rcases ct.universal_result terminates m m_is_model with ⟨res, hom, res_mem, hom_is_hom⟩
+    unfold CoreTreeDerivation.result at res_mem
+    rcases res_mem with ⟨b, b_mem, res_mem⟩
+    have b_mem := TreeDerivation.branches_eq_firstBranch_of_determinsitic det _ b_mem
+    unfold CoreTreeDerivation.firstResult
+    unfold CoreChaseDerivation.result
+    simp only [← b_mem, res_mem]
+    exact ⟨_, hom_is_hom⟩
+
+end CoreChaseTree
+
+namespace CoreChaseDerivation
+
+variable {rules : RuleSet sig}
+
+/-- The `firstResult` of `intoTree` is the original `ChaseDerivationSkeleton.result`. -/
+theorem firstResult_intoTree_eq_result (cd : CoreChaseDerivation rules) (det : rules.isDeterministic) (terminates : cd.terminates) :
+    CoreTreeDerivation.firstResult (cd.intoTree det) (by unfold TreeDerivation.terminates; intro branch branch_mem; rw [cd.branches_intoTree det _ branch_mem]; exact terminates) = cd.result terminates := by
+  unfold CoreTreeDerivation.firstResult
+  congr
+  exact cd.firstBranch_intoTree_eq_self det
+
+end CoreChaseDerivation
 
 namespace CoreChaseBranch
 
 variable {kb : KnowledgeBase sig}
 
--- TODO: This duplicates a lot of the universality proof of the regular chase derivations. A lot is already generalized over there but it all works on trees, which is why we cannot simply reuse it here... Unify this in the future!
-
-theorem extend_hom_to_next
-    {cb : CoreChaseBranch kb} {cd : CoreChaseDerivation kb.rules} {m : FactSet sig} {h : GroundTermMapping sig} :
-    cd <:+ cb.toChaseDerivation -> kb.isDeterministic -> m.modelsRules kb.rules -> h.isHomomorphism cd.head.core m ->
-    ∀ next ∈ cd.next, ∃ (h' : GroundTermMapping sig), h'.isHomomorphism next.core m := by
-  intro suf det m_is_model h_hom next next_mem
-
-  let orig := next.origin.get (cd.isSome_origin_next next_mem)
-  let trg := orig.fst
-  have trg_act : trg.val.active cd.head.core := cd.active_trigger_origin_next next_mem
-  have trg_rule_det : trg.val.rule.head.length = 1 := by
-    have := det _ trg.property; unfold Rule.isDeterministic at this; rw [decide_eq_true_iff] at this; exact this
-  have orig_snd_zero : orig.snd.val = 0 := by
-    have isLt := orig.snd.isLt; unfold trg at trg_rule_det; simp only [PreTrigger.length_mapped_head, trg_rule_det] at isLt; grind
-
-  let trg_variant_for_m : RTrigger (RestrictedObsolescence sig) kb.rules := {
-    val := {
-      rule := trg.val.rule
-      subs := fun t => h (trg.val.subs t)
-    }
-    property := trg.property
-  }
-  have trg_variant_loaded_for_m : trg_variant_for_m.val.loaded m := by
-    suffices trg_variant_for_m.val.loaded (h.applyFactSet cd.head.core) by
-      exact Set.subset_trans this h_hom.right
-    apply PreTrigger.term_mapping_preserves_loadedness
-    . exact h_hom.left
-    . exact trg_act.left
-  have trg_variant_satisfied_on_m : trg_variant_for_m.val.satisfied_for_disj m ⟨0, by rw [trg_rule_det]; simp⟩ := by
-    suffices trg_variant_for_m.val.satisfied m by
-      rcases this with ⟨idx, goal⟩
-      have : idx = ⟨0, by rw [trg_rule_det]; simp⟩ := by have isLt := idx.isLt; simp only [trg_variant_for_m, trg_rule_det] at isLt; grind
-      simp only [this] at goal
-      exact goal
-    have m_models_rule : m.modelsRule trg_variant_for_m.val.rule := by exact m_is_model trg.val.rule trg.property
-    unfold FactSet.modelsRule at m_models_rule
-    apply m_models_rule
-    apply trg_variant_loaded_for_m
-
-  rcases trg_variant_satisfied_on_m with ⟨obs_for_m_subs, obs_for_m_subs_spec⟩
-
-  let next_hom : GroundTermMapping sig := fun t =>
-    let t_in_node := t ∈ cd.head.core.terms
-    have t_in_node_dec := Classical.propDecidable t_in_node
-    if t_in_node then h t else
-      let t_fresh := t ∈ trg.val.fresh_terms_for_head_disjunct 0 (by rw [trg_rule_det]; simp)
-      have t_fresh_dec := Classical.propDecidable t_fresh
-      if t_fresh_true : t_fresh then
-        obs_for_m_subs (trg.val.existential_var_for_fresh_term _ _ t t_fresh_true)
-      else t
-
-  have next_hom_id_const : next_hom.isIdOnConstants := by
-    intro c
-    simp only [next_hom]
-    split
-    . exact h_hom.left
-    . split
-      case isFalse _ => rfl
-      case isTrue h => rcases trg.val.term_functional_of_mem_fresh_terms _ h with ⟨_, _, _, contra⟩; have contra := Eq.symm contra; simp [GroundTerm.func_neq_const] at contra
-
-  exists next_hom; constructor; exact next_hom_id_const
-  intro mapped_f
-  rw [GroundTermMapping.mem_applyFactSet]
-  intro ⟨f, f_mem, mapped_f_eq⟩
-  have f_mem := next.homSubset.left _ f_mem
-  rw [← CoreChaseNode.ingoingFacts_eq, cd.facts_next next_mem] at f_mem
-  rw [mapped_f_eq]
-  cases f_mem with
-  | inl f_mem =>
-    apply h_hom.right
-    rw [GroundTermMapping.mem_applyFactSet]
-    exists f; rw [CoreChaseNode.outgoingFacts_eq] at f_mem; simp only [f_mem, true_and]
-    apply TermMapping.apply_generalized_atom_congr_left
-    intro t t_mem
-    have t_mem : t ∈ cd.head.core.terms := by exists f
-    simp [next_hom, t_mem]
-  | inr f_mem =>
-    have f_mem : f ∈ trg.val.mapped_head[0] := by
-      rw [List.mem_toSet, ChaseNode.origin_result_eq _ (trg := trg.val.toPreTrigger) (i := 0)] at f_mem; exact f_mem
-      . rfl
-      . exact Eq.symm orig_snd_zero
-    apply obs_for_m_subs_spec.right
-    rw [List.mem_toSet]
-    rw [GroundSubstitution.apply_function_free_conj, TermMapping.apply_generalized_atom_list]
-    rw [List.mem_map]
-    exists (trg.val.atom_for_result_fact ⟨0, by rw [PreTrigger.length_mapped_head, trg_rule_det]; simp⟩ f_mem); constructor
-    . apply PreTrigger.atom_for_result_fact_mem_head
-    conv => right; rw [← trg.val.apply_on_atom_for_result_fact_is_fact ⟨0, by rw [PreTrigger.length_mapped_head, trg_rule_det]; simp⟩ f_mem]
-    rw [← PreTrigger.apply_subs_for_atom_eq]
-    unfold GroundTermMapping.applyFact
-    rw [← Function.comp_apply (f := TermMapping.apply_generalized_atom next_hom)]
-    rw [← GroundTermMapping.applyFact.eq_def, ← GroundSubstitution.apply_function_free_atom_compose_of_isIdOnConstants _ _ next_hom_id_const]
-    apply TermMapping.apply_generalized_atom_congr_left
-    intro voc voc_mem
-    cases voc with
-    | const c => simp [GroundSubstitution.apply_var_or_const]
-    | var v =>
-      rw [GroundSubstitution.apply_var_or_const_compose_of_isIdOnConstants _ _ next_hom_id_const]
-      rw [Function.comp_apply, PreTrigger.apply_subs_for_var_or_const_eq]
-      simp only [GroundSubstitution.apply_var_or_const]
-      cases Decidable.em (v ∈ trg.val.rule.frontier) with
-      | inl v_front =>
-        rw [obs_for_m_subs_spec.left v v_front]
-        rw [PreTrigger.apply_to_var_or_const_frontier_var _ _ _ v_front]
-        simp only [trg_variant_for_m, next_hom]
-        suffices trg.val.subs v ∈ cd.head.core.terms by simp [this]
-        apply FactSet.terms_subset_of_subset trg_act.left
-        rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
-        apply Or.inr
-        exists v; constructor
-        . apply Rule.frontier_subset_vars_body; exact v_front
-        . rfl
-      | inr v_front =>
-        have v_exis : v ∈ trg.val.rule.existential_vars_for_head_disjunct 0 (by rw [trg_rule_det]; simp) := by
-          simp only [Rule.existential_vars_for_head_disjunct, List.mem_filter, decide_eq_true_eq]; constructor
-          . rw [FunctionFreeConjunction.mem_vars];
-            exists (trg.val.atom_for_result_fact ⟨0, by rw [PreTrigger.length_mapped_head, trg_rule_det]; simp⟩ f_mem); constructor
-            . apply PreTrigger.atom_for_result_fact_mem_head
-            . exact voc_mem
-          . exact v_front
-        have func_term_fresh : trg.val.functional_term_for_var 0 v ∈ trg.val.fresh_terms_for_head_disjunct 0 (by rw [trg_rule_det]; simp) := by apply List.mem_map_of_mem; exact v_exis
-        rw [PreTrigger.apply_to_var_or_const_non_frontier_var _ _ _ v_front]
-        simp only [next_hom]
-        suffices ¬ trg.val.functional_term_for_var 0 v ∈ cd.head.core.terms by
-          simp only [this, ↓reduceIte]
-          simp only [func_term_fresh, ↓reduceDIte]
-          rw [PreTrigger.existential_var_for_fresh_term_after_functional_term_for_var]
-          exact v_exis
-        intro contra
-        -- from here this is a bit different than for the regular chase derivation
-        rcases cb.trigger_introducing_functional_term_occurs_in_chase ⟨cd.head, cd.mem_of_mem_suffix suf _ cd.head_mem⟩ (FactSet.terms_subset_of_subset cd.head.homSubset.left _ contra) func_term_fresh with ⟨node2, prec, orig2, orig2_mem, equiv, orig2_snd_zero⟩
-        apply cb.origin_trg_remains_inactive prec _ orig2_mem _ equiv
-        exact trg_act
-
-theorem extend_hom_to_each
-    {cb : CoreChaseBranch kb} {cd : CoreChaseDerivation kb.rules} {m : FactSet sig} {h : GroundTermMapping sig} :
-    cd <:+ cb.toChaseDerivation -> kb.isDeterministic -> m.modelsRules kb.rules -> h.isHomomorphism cd.head.core m ->
-    ∀ node ∈ cd, ∃ (h' : GroundTermMapping sig), h'.isHomomorphism node.core m := by
-  intro suf det m_is_model h_hom node node_mem
-  let node : cd.Node := ⟨node, node_mem⟩
-  show ∃ (h' : GroundTermMapping sig), h'.isHomomorphism node.val.core m
-  induction node using cd.mem_rec with
-  | head => exists h
-  | step cd2 suf2 ih next next_mem =>
-    rcases ih with ⟨ig_h, ih_h_hom⟩
-    exact cb.extend_hom_to_next (PossiblyInfiniteList.IsSuffix_trans suf2 suf) det m_is_model ih_h_hom next next_mem
-
-theorem extend_hom_prec
-    {cb : CoreChaseBranch kb} {m : FactSet sig} {h : GroundTermMapping sig} :
-    kb.isDeterministic -> m.modelsRules kb.rules ->
-    ∀ (n1 n2 : cb.Node), n1 ≼ n2 -> h.isHomomorphism n1.val.core m -> ∃ (h' : GroundTermMapping sig), h'.isHomomorphism n2.val.core m := by
-  intro det m_is_model n1 n2 prec h_hom
-  rw [cb.predecessor_iff] at prec; rcases prec with ⟨cd, suf, head_eq, n2_mem⟩
-  exact extend_hom_to_each suf det m_is_model (by rw [head_eq]; exact h_hom) _ n2_mem
-
-public theorem result_universallyModels_kb {cb : CoreChaseBranch kb} (det : kb.isDeterministic) (term : cb.terminates) :
-    (CoreChaseDerivation.result cb.toChaseDerivation term).universallyModelsKb kb := by
-  constructor; exact cb.result_models_kb term
-  intro m m_is_model
-  suffices GroundTermMapping.isHomomorphism id cb.head.core m by
-    exact cb.extend_hom_prec det m_is_model.right ⟨cb.head, cb.head_mem⟩ ⟨cb.last term, cb.last_mem term⟩ (cb.each_prec_last term _) this
-  apply GroundTermMapping.isHomomorphism_id_of_subset
-  intro f f_mem
-  apply m_is_model.left
-  rw [← cb.database_first'.right.left, CoreChaseNode.outgoingFacts_eq]
-  exact f_mem
+theorem result_universallyModels_kb {cb : CoreChaseBranch kb} (det : kb.isDeterministic) (terminates : cb.terminates) :
+    (CoreChaseDerivation.result cb.toChaseDerivation terminates).universallyModelsKb kb := by
+  unfold CoreChaseDerivation.result
+  have eq := CoreChaseDerivation.firstResult_intoTree_eq_result cb.toChaseDerivation det terminates
+  unfold CoreChaseDerivation.result at eq
+  rw [← eq]
+  apply CoreChaseTree.deterministicChaseTreeResultUniversallyModelsKb (ct := (cb.intoTree det)) det
 
 end CoreChaseBranch
+
+end CoreChaseDeterministic
 

--- a/ExistentialRules/ChaseSequence/Deterministic.lean
+++ b/ExistentialRules/ChaseSequence/Deterministic.lean
@@ -18,7 +18,7 @@ Here, `ChaseTree` and `ChaseBranch` consequently coincide. At least intuitively.
 Arguably the most interesting result of this file is `deterministicChaseBranchResultUniversallyModelsKb`.
 It states that in the deterministic setting, the result of a `ChaseBranch` is itself a universal model.
 That is, a model that can be homomorphically embedded into every other model [ChaseRevisited].
-On disjunctive rules this is more complicated as can be seen in `chaseTreeResultIsUniversal`.
+On disjunctive rules this is more complicated as can be seen in `RegularChaseTree.universal_result`.
 -/
 
 public section
@@ -130,13 +130,16 @@ theorem branches_start_eq_firstBranch_from_start
 def firstBranch (td : TreeDerivation N obs rules) : ChaseDerivation N obs rules :=
   td.firstBranch_from_start (NodeWithAddress.root td)
 
+/-- The first branch is a branch. This holds in general and not only in the deterministic setting. -/
+theorem firstBranch_mem_branches {td : TreeDerivation N obs rules} : td.firstBranch ∈ td.branches := by
+  apply td.generate_subderivation_mem_branches rfl
+  . intro _ _ mem; exact List.mem_of_getElem? mem
+  . intro node eq; rw [← List.head?_eq_getElem?, List.head?_eq_none_iff, ← List.length_eq_zero_iff, node.length_childNodes, node.subderivation.childNodes_eq, List.length_map] at eq; rw [← List.length_eq_zero_iff]; exact eq
+
 /-- In the deterministic setting, the branches of a `TreeDerivation` only contain the `firstBranch`. -/
 theorem branches_eq_firstBranch_of_determinsitic {td : TreeDerivation N obs rules} (det : rules.isDeterministic) :
-    td.branches = fun b => b = td.firstBranch := by
-  ext deriv
-  constructor
-  . intro deriv_mem; apply branches_start_eq_firstBranch_from_start det; rw [NodeWithAddress.subderivation_root]; exact deriv_mem
-  . intro eq; rw [eq]; simp only [firstBranch, firstBranch_from_start]; exact td.generate_subderivation_mem_branches rfl
+    ∀ b ∈ td.branches, b = td.firstBranch := by
+  intro deriv deriv_mem; apply branches_start_eq_firstBranch_from_start det; rw [NodeWithAddress.subderivation_root]; exact deriv_mem
 
 end TreeDerivation
 
@@ -150,8 +153,8 @@ def firstResult (td : RegularTreeDerivation obs rules) : FactSet sig := RegularC
 /-- The `firstResult` is a member of the `TreeDerivation.result`. -/
 theorem firstResult_mem_result {td : RegularTreeDerivation obs rules} : td.firstResult ∈ td.result := by
   unfold RegularTreeDerivation.result; rw [Set.mem_map]
-  exists td.firstBranch; constructor;
-  . simp only [TreeDerivation.firstBranch, TreeDerivation.firstBranch_from_start]; exact td.generate_subderivation_mem_branches rfl
+  exists td.firstBranch; constructor
+  . exact td.firstBranch_mem_branches
   . rfl
 
 end RegularTreeDerivation
@@ -160,17 +163,17 @@ namespace RegularChaseTree
 
 variable {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig}
 
-/-- In the deterministic setting, the `firstResult` of a `ChaseTree` is by itself a universal model. -/
+/-- In the deterministic setting, the `firstResult` of a `RegularChaseTree` is by itself a universal model. -/
 theorem deterministicChaseTreeResultUniversallyModelsKb {ct : RegularChaseTree obs kb} :
     kb.isDeterministic -> (RegularTreeDerivation.firstResult ct.toTreeDerivation).universallyModelsKb kb := by
   intro det
   constructor
   . apply ct.result_models_kb; exact RegularTreeDerivation.firstResult_mem_result
   . intro m m_is_model
-    rcases chaseTreeResultIsUniversal ct m m_is_model with ⟨res, hom, res_mem, hom_is_hom⟩
+    rcases ct.universal_result m m_is_model with ⟨res, hom, res_mem, hom_is_hom⟩
     unfold RegularChaseTree.result RegularTreeDerivation.result at res_mem; rw [Set.mem_map] at res_mem
     rcases res_mem with ⟨b, b_mem, res_mem⟩
-    rw [TreeDerivation.branches_eq_firstBranch_of_determinsitic det] at b_mem
+    have b_mem := TreeDerivation.branches_eq_firstBranch_of_determinsitic det _ b_mem
     unfold RegularTreeDerivation.firstResult
     unfold RegularChaseDerivation.result
     rw [← b_mem, res_mem]
@@ -365,6 +368,12 @@ theorem firstBranch_intoTree_eq_self (cd : ChaseDerivation N obs rules) (det : r
   apply firstBranch_from_start_with_intoTree_eq_cd det
   rw [TreeDerivation.NodeWithAddress.subderivation_root]
 
+/-- The branches of `intoTree` consist only of the original derivation. -/
+theorem branches_intoTree {cd : ChaseDerivation N obs rules} (det : rules.isDeterministic) :
+    ∀ d ∈ (cd.intoTree det).branches, d = cd := by
+  intro d d_mem
+  rw [TreeDerivation.branches_eq_firstBranch_of_determinsitic det _ d_mem, firstBranch_intoTree_eq_self cd det]
+
 end ChaseDerivation
 
 namespace RegularChaseDerivation
@@ -383,6 +392,7 @@ namespace ChaseBranch
 variable {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig}
 
 /-- We can not only convert a `ChaseDerivation` into a `TreeDerivation` but also a `ChaseBranch` into a `ChaseTree`. -/
+@[expose]
 def intoTree {N : Type u} [CN : ChaseNode N obs kb.rules] (cb : ChaseBranch N obs kb) (det : kb.isDeterministic) : ChaseTree N obs kb :=
   let td := cb.toChaseDerivation.intoTree det
   {

--- a/ExistentialRules/ChaseSequence/Termination/Basic.lean
+++ b/ExistentialRules/ChaseSequence/Termination/Basic.lean
@@ -78,6 +78,7 @@ variable {obs : ObsolescenceCondition sig} {rules : RuleSet sig}
 variable {N : Type u} [CN : ChaseNode N obs rules]
 
 /-- For terminating derivations, we define the last chase node via turning the derivation into a finite list and then retreiving the last element. -/
+@[expose]
 def last (cd : ChaseDerivationSkeleton N obs rules) (term : cd.terminates) : N := (cd.branch.toList_of_finite term).getLast (by
   intro contra
   rw [PossiblyInfiniteList.toList_of_finite_empty_iff, PossiblyInfiniteList.empty_iff_head_none] at contra

--- a/ExistentialRules/ChaseSequence/TreeDerivation.lean
+++ b/ExistentialRules/ChaseSequence/TreeDerivation.lean
@@ -462,6 +462,21 @@ theorem address_getElem_childNodes {td : TreeDerivation N obs rules} {node : Nod
     ∀ i (lt : i < node.childNodes.length), node.childNodes[i].address = node.address ++ [i] := by
   intro i lt; simp only [childNodes]; grind
 
+/-- We can lift membership in childNodes along `cast_for_new_root_node`. -/
+theorem cast_for_new_root_node_mem_chilNodes_cast_for_new_root_node_of_mem_childNodes
+    {td : TreeDerivation N obs rules} {new_root : NodeWithAddress td} {n1 n2 : new_root.subderivation.NodeWithAddress} :
+    n2 ∈ n1.childNodes -> new_root.cast_for_new_root_node n2 ∈ (new_root.cast_for_new_root_node n1).childNodes := by
+  intro n2_mem
+  simp only [NodeWithAddress.childNodes, List.mem_map, List.mem_attach] at n2_mem
+  rcases n2_mem with ⟨⟨⟨n2_node, n2_index⟩, mem_zipIdx⟩, _, n2_mem⟩
+  rw [List.mem_zipIdx_with_lt_iff_mem_zipIdx] at mem_zipIdx
+  rw [← n2_mem]
+  simp only [NodeWithAddress.childNodes, List.mem_map, List.mem_attach]
+  suffices n1.subderivation = (new_root.cast_for_new_root_node n1).subderivation by
+    exists ⟨⟨n2_node, ⟨n2_index, by rw [← this]; exact n2_index.isLt⟩⟩, by simp only [List.mem_zipIdx_with_lt_iff_mem_zipIdx, ← this]; exact mem_zipIdx⟩
+    simp [NodeWithAddress.cast_for_new_root_node]
+  simp [NodeWithAddress.subderivation, NodeWithAddress.cast_for_new_root_node, TreeDerivation.derivation_for_suffix]
+
 /-- The subderivation for a child node is a child tree. -/
 @[grind ->]
 theorem subderivation_mem_childTrees_of_mem_childNodes
@@ -620,6 +635,32 @@ theorem mem_some_childTree_iff {td : TreeDerivation N obs rules} {node : N} :
         apply mem_of_mem_childNodes
         exact node_mem
 
+/-- If a node occurs in the subderivation of a child of the root, then this node also occurs as the child node of some node in the tree.
+This is essentially the `NodeWithAddress` version of `mem_some_childTree_iff` above and uses essentially the same proof for the first direction. -/
+theorem mem_subderivation_childNodes_iff {td : TreeDerivation N obs rules} {node : td.NodeWithAddress} :
+    (∃ child ∈ NodeWithAddress.childNodes (NodeWithAddress.root td),
+      ∃ node' : child.subderivation.NodeWithAddress, NodeWithAddress.cast_for_new_root_node child node' = node)
+    ↔ ∃ (node' : td.NodeWithAddress), node ∈ node'.childNodes := by
+  constructor
+  . intro ⟨c, c_mem, node', node_eq⟩
+    induction node' using mem_rec_address generalizing node with
+    | root => exists (NodeWithAddress.root td); simp only [NodeWithAddress.root_subderivation, NodeWithAddress.cast_for_new_root_node] at node_eq; rw [← node_eq]; simp only [List.append_nil]; exact c_mem
+    | step new_root ih c2 c2_mem =>
+      exists c.cast_for_new_root_node new_root
+      rw [← node_eq]
+      apply NodeWithAddress.cast_for_new_root_node_mem_chilNodes_cast_for_new_root_node_of_mem_childNodes
+      exact c2_mem
+  . intro ⟨node', node_mem⟩
+    cases node.eq_root_or_mem_child with
+    | inl mem =>
+      exfalso
+      rw [List.mem_iff_getElem] at node_mem; rcases node_mem with ⟨i, lt, node_mem⟩
+      suffices (NodeWithAddress.root td).address = node'.childNodes[i].address by
+        rw [NodeWithAddress.address_getElem_childNodes] at this
+        simp [NodeWithAddress.root] at this
+      rw [node_mem, mem]
+    | inr mem => exact mem
+
 end InductionPrinciple
 
 end Basics
@@ -686,6 +727,28 @@ variable {N : Type u} [CN : ChaseNode N obs rules]
 @[expose]
 def predecessor {td : TreeDerivation N obs rules} (n1 n2 : NodeWithAddress td) : Prop := n1.address <+: n2.address
 infixl:50 " ≼ " => predecessor
+
+/--
+A node n1 is a predecessor of another node n2 if and only if there exists a node in the subderivation of n1 that is equal to n2
+(when casting it back to a node of the original `TreeDerivation`).
+-/
+theorem predecessor_iff {td : TreeDerivation N obs rules} {n1 n2 : NodeWithAddress td} :
+    n1 ≼ n2 ↔ ∃ n2' : n1.subderivation.NodeWithAddress, n1.cast_for_new_root_node n2' = n2 := by
+  constructor
+  . intro prec
+    have addr_eq : n2.address = n1.address ++ (n2.address.drop n1.address.length) := by
+      apply Eq.symm; apply List.prefix_iff_eq_append.mp; exact prec
+    exists {
+      node := n2.node,
+      address := n2.address.drop n1.address.length,
+      eq := by rw [← n2.eq]; simp only [NodeWithAddress.subderivation, derivation_for_suffix, FiniteDegreeTree.get?_drop, ← addr_eq]
+    }
+    apply NodeWithAddress.eq_of_address_eq
+    simp only [NodeWithAddress.cast_for_new_root_node]
+    exact Eq.symm addr_eq
+  . intro ⟨n2', n2_eq⟩
+    rw [← n2_eq]
+    apply List.prefix_append
 
 /-- The predecessor relation is stable across suffixes. That is, predecessor in our suffix are also predecessor for us. We only need to cast the nodes. -/
 @[grind <-]
@@ -858,6 +921,30 @@ theorem next_on_path_to_succ_is_prec {td : TreeDerivation N obs rules} {n1 n2 : 
   rw [List.append_assoc, List.singleton_append]
   rw [List.cons_head_tail, ← List.prefix_iff_eq_append]
   exact succ.left
+
+/-- If a node is a strict successor of another, then it occurs as the child of a node which is at least a regular successor. -/
+theorem mem_childNodes_of_some_node_of_strict_prec {td : TreeDerivation N obs rules} {n1 n2 : NodeWithAddress td} :
+    n1 ≺ n2 -> ∃ n3, n1 ≼ n3 ∧ n2 ∈ n3.childNodes := by
+  intro ⟨prec, ne⟩
+  rw [predecessor_iff] at prec; rcases prec with ⟨n2', n2_eq⟩
+  suffices ∃ (n3' : n1.subderivation.NodeWithAddress), n2' ∈ n3'.childNodes by
+    rcases this with ⟨n3', n2'_mem⟩
+    exists n1.cast_for_new_root_node n3'; constructor
+    . apply List.prefix_append
+    . rw [← n2_eq]
+      apply NodeWithAddress.cast_for_new_root_node_mem_chilNodes_cast_for_new_root_node_of_mem_childNodes
+      exact n2'_mem
+  rw [← mem_subderivation_childNodes_iff]
+  have n1_root_prec_n2' : (NodeWithAddress.root n1.subderivation) ≺ n2' := by
+    constructor
+    . simp only [NodeWithAddress.root]; exact List.nil_prefix
+    . intro contra; apply ne
+      apply NodeWithAddress.eq_of_address_eq
+      rw [← n2_eq, ← contra]
+      simp [NodeWithAddress.root, NodeWithAddress.cast_for_new_root_node]
+  exists next_on_path_to_succ n1_root_prec_n2'; constructor
+  . exact next_on_path_to_succ_mem_childNodes n1_root_prec_n2'
+  . rw [← predecessor_iff]; exact next_on_path_to_succ_is_prec n1_root_prec_n2'
 
 end StrictPredecessor
 

--- a/ExistentialRules/ChaseSequence/TreeDerivation.lean
+++ b/ExistentialRules/ChaseSequence/TreeDerivation.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 module
 
+import BasicLeanDatastructures.WellFounded
+
 public import PossiblyInfiniteTrees.PossiblyInfiniteTree.FiniteDegreeTree.Basic
 
 public import ExistentialRules.ChaseSequence.ChaseDerivation
@@ -720,6 +722,14 @@ theorem node_prec_childNodes {td : TreeDerivation N obs rules} {node : NodeWithA
   rw [← n_mem, NodeWithAddress.address_getElem_childNodes]
   exact List.prefix_append _ _
 
+/-- If n2 is a successor of n1, then n2 must occurs in the subtree induced by n1. -/
+theorem mem_subderivation_of_prec {td : TreeDerivation N obs rules} {n1 n2 : NodeWithAddress td} : n1 ≼ n2 -> n2.node ∈ n1.subderivation := by
+  intro ⟨diff, addr_eq⟩
+  rw [mem_iff]
+  exists diff
+  simp only [NodeWithAddress.subderivation, derivation_for_suffix]
+  rw [← n2.eq, ← addr_eq]
+  simp
 
 section StrictPredecessor
 
@@ -851,8 +861,73 @@ theorem next_on_path_to_succ_is_prec {td : TreeDerivation N obs rules} {n1 n2 : 
 
 end StrictPredecessor
 
+section WellFounded
+
+/-- The `strict_predecessor` relation is `WellFounded`. -/
+theorem wellFounded_pred {td : TreeDerivation N obs rules} : WellFounded td.strict_predecessor := by
+  constructor; intro node
+  induction node using td.mem_rec_address with
+  | root =>
+    constructor; intro node ⟨prec, ne⟩
+    exfalso
+    simp only [predecessor, NodeWithAddress.root, List.prefix_nil] at prec
+    apply ne; apply NodeWithAddress.eq_of_address_eq; rw [prec]; simp [NodeWithAddress.root]
+  | step new_root ih c c_mem =>
+    constructor
+    intro n2 prec
+    suffices n2 = new_root ∨ n2 ≺ new_root by
+      cases this with
+      | inl eq => rw [eq]; exact ih
+      | inr prec => rcases ih with ⟨_, ih⟩; apply ih; exact prec
+    have root_prec_c := node_prec_childNodes c c_mem
+    cases List.prefix_or_prefix_of_prefix prec.left root_prec_c with
+    | inl prec' => apply td.eq_or_strict_of_predecessor; exact prec'
+    | inr prec' =>
+      cases td.eq_or_strict_of_predecessor prec' with
+      | inl eq => apply Or.inl; exact Eq.symm eq
+      | inr prec' =>
+        exfalso
+        apply prec.right
+        apply NodeWithAddress.eq_of_address_eq
+        apply List.IsPrefix.eq_of_length_le prec.left
+        rw [List.mem_iff_getElem] at c_mem; rcases c_mem with ⟨i, _, c_mem⟩
+        rw [← c_mem, NodeWithAddress.address_getElem_childNodes]
+        suffices new_root.address.length < n2.address.length by grind
+        apply Nat.lt_of_le_of_ne
+        . exact List.IsPrefix.length_le prec'.left
+        . intro contra; apply prec'.right
+          apply NodeWithAddress.eq_of_address_eq; apply List.IsPrefix.eq_of_length prec'.left
+          exact contra
+
+instance {td : TreeDerivation N obs rules} : WellFoundedRelation td.NodeWithAddress where
+  rel := td.strict_predecessor
+  wf := wellFounded_pred
+
+end WellFounded
+
 end Predecessors
 
+section MinimalNodeWithProp
+
+/-!
+## Minimal Nodes with given Properties
+
+If a property hold for a given node in the chase, then there must be a "first" node for which this property holds. That means that this node is minimal with respect to the `≺` relation.
+The result follows by the well foundedness of the `≺` relation.
+-/
+
+theorem prop_for_node_has_minimal_such_node {N : Type u} [CN : ChaseNode N obs rules]
+    {td : TreeDerivation N obs rules} (prop : td.NodeWithAddress -> Prop) :
+    ∀ n, prop n -> ∃ n2, prop n2 ∧ n2 ≼ n ∧ ∀ n3, n3 ≺ n2 -> ¬ prop n3 := by
+  intro n prop_n
+  rcases minimal_element_for_property_and_transitive_relation (by intro _ _ _; exact td.strict_predecessor_trans) prop n prop_n with ⟨n2, prop_n2, prec_n2, n2_min⟩
+  exists n2; constructor; exact prop_n2; constructor
+  . cases prec_n2 with
+    | inl prec_n2 => grind
+    | inr prec_n2 => exact prec_n2.left
+  . exact n2_min
+
+end MinimalNodeWithProp
 
 section Branches
 

--- a/ExistentialRules/ChaseSequence/Universality.lean
+++ b/ExistentialRules/ChaseSequence/Universality.lean
@@ -18,7 +18,7 @@ So what exactly remains to be shown?
 
 We aim to show that for a given `ChaseTree` for a `KnowledgeBase` and any model $M$ of the `KnowledgeBase`,
 we can pick a fact set $F$ from the result of the chase tree such that there is a homomorphism from $F$ to $M$.
-This result is shown in `chaseTreeResultIsUniversal`.
+This result is shown in `RegularChaseTree.universal_result`.
 
 The proof works by step-wise construction of both a branch in the chase tree as well as a suitable homomorphism.
 The constructions builds both at the same time.
@@ -26,20 +26,27 @@ One step of the construction is done by the `hom_step` function below, which cal
 The base of the construction is simply an empty branch and the id mapping.
 In each step of the construction, we consider an `InductiveHomomorphismResult`, which we define to be a pair of a node in the chase tree and a `GroundTermMapping` such that the mapping is a homomorphism from the node into the model $M$.
 
-In the proof of `chaseTreeResultIsUniversal`, we leverage the `TreeDerivation.generate_subderivation` function with `hom_step` as the generator function.
+In the proof of `RegularChaseTree.universal_result`,
+we leverage the `TreeDerivation.generate_subderivation` function with `hom_step` as the generator function.
 Besides that, all the homomorphisms from the individual steps need to be combined into a single function. The definition is not too hard and all relevant properties are also not too hard to show once we can establish that the homomorphisms for each step always extend the previous one.
 -/
 
+public section
+
 variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
+
+namespace AuxiliaryDefsAndTheoremsForUniversalityProof
+
 variable {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig}
+variable {N : Type u} [CN : ChaseNode N obs kb.rules]
 
 /-- The `InductiveHomomorphismResult` is used for the step-wise construction is forms the element that is the input and output of the generator function used in `TreeDerivation.generate_subderivation` later. It consists of a node in the chase tree and a `GroundTermMapping` that is a homomorphism from the node to the target model. The generated branch is the chain of all the generated nodes.  -/
-abbrev InductiveHomomorphismResult {N : Type u} [CN : ChaseNode N obs kb.rules] (ct : ChaseTree N obs kb) (m : FactSet sig) :=
+abbrev InductiveHomomorphismResult (ct : ChaseTree N obs kb) (m : FactSet sig) :=
   { pair : ct.NodeWithAddress × (GroundTermMapping sig) // pair.snd.isHomomorphism (CN.outgoingFacts pair.fst.node) m }
 
 /-- Consider any node in the chase tree together with a homomorphism from this node to the target model. Given that the list of child nodes is not empty, we return one of child node together with an extended homomorphism. How do we know that such a node and homomorphism exist? If the list of children is not empty, there needs to exists a trigger that has been used to derive them. The existing trigger is loaded for the target model but since it is a model, we can also show that it also needs to be satisfied for the model. The way in which the trigger is satisfied in the model dictates which child node we pick and how we define the homomorphisms for the fresh terms introduced by the trigger. This is already all that happens here but it is not quite trivial to show that the constructed `GroundTermMapping` is indeed a homomorphism. -/
 noncomputable def hom_step_of_trg_ex
-    {N : Type u} [CN : ChaseNode N obs kb.rules] (out_sub_in : CN.out_sub_in)
+    (out_sub_in : CN.out_sub_in)
     (ct : ChaseTree N obs kb)
     (m : FactSet sig)
     (m_is_model : m.modelsKb kb)
@@ -193,7 +200,7 @@ noncomputable def hom_step_of_trg_ex
 
 /-- The node that we pick in `hom_step_of_trg_ex` is in the childNodes of the previous node. This is trivial. -/
 theorem mem_childNodes_of_mem_hom_step_of_trg_ex
-    {N : Type u} [CN : ChaseNode N obs kb.rules] {out_sub_in : CN.out_sub_in}
+    {out_sub_in : CN.out_sub_in}
     {ct : ChaseTree N obs kb}
     {m : FactSet sig}
     {m_is_model : m.modelsKb kb}
@@ -207,7 +214,7 @@ theorem mem_childNodes_of_mem_hom_step_of_trg_ex
 
 /-- The homomorphisms that we construct in `hom_step_of_trg_ex` agrees with the previous one on all terms in the previous node. This is also trivial. -/
 theorem hom_extends_prev_in_hom_step_of_trg_ex
-    {N : Type u} [CN : ChaseNode N obs kb.rules] {out_sub_in : CN.out_sub_in}
+    {out_sub_in : CN.out_sub_in}
     {ct : ChaseTree N obs kb}
     {m : FactSet sig}
     {m_is_model : m.modelsKb kb}
@@ -220,7 +227,7 @@ theorem hom_extends_prev_in_hom_step_of_trg_ex
 
 /-- When extending the `InductiveHomomorphismResult` from one step to the next, we do not necessarily know that a trigger is active for the current node. Indeed the chase might just have already finished. So we do a simple case distinction here and return an `Option` either with the result from `hom_step_of_trg_ex` or simply none. -/
 noncomputable def hom_step
-    {N : Type u} [CN : ChaseNode N obs kb.rules] (out_sub_in : CN.out_sub_in)
+    (out_sub_in : CN.out_sub_in)
     (ct : ChaseTree N obs kb)
     (m : FactSet sig)
     (m_is_model : m.modelsKb kb)
@@ -233,7 +240,7 @@ noncomputable def hom_step
 
 /-- If there is a new node returned by `hom_step`, then it is in the `childNodes` of the current node. -/
 theorem mem_childNodes_of_mem_hom_step
-    {N : Type u} [CN : ChaseNode N obs kb.rules] {out_sub_in : CN.out_sub_in}
+    {out_sub_in : CN.out_sub_in}
     {ct : ChaseTree N obs kb}
     {m : FactSet sig}
     {m_is_model : m.modelsKb kb}
@@ -246,7 +253,7 @@ theorem mem_childNodes_of_mem_hom_step
 
 /-- If `hom_step` returns none, then the current node does not have any children. -/
 theorem childNodes_empty_of_hom_step_none
-    {N : Type u} [CN : ChaseNode N obs kb.rules] {out_sub_in : CN.out_sub_in}
+    {out_sub_in : CN.out_sub_in}
     {ct : ChaseTree N obs kb}
     {m : FactSet sig}
     {m_is_model : m.modelsKb kb}
@@ -260,7 +267,7 @@ theorem childNodes_empty_of_hom_step_none
 
 /-- The homomorphism returns in `hom_step` agrees with the current one on all terms from the current node. -/
 theorem hom_extends_prev_in_hom_step
-    {N : Type u} [CN : ChaseNode N obs kb.rules] {out_sub_in : CN.out_sub_in}
+    {out_sub_in : CN.out_sub_in}
     {ct : ChaseTree N obs kb}
     {m : FactSet sig}
     {m_is_model : m.modelsKb kb}
@@ -272,17 +279,12 @@ theorem hom_extends_prev_in_hom_step
   simp only [hom_step]
   grind [hom_extends_prev_in_hom_step_of_trg_ex]
 
-/-- As outlined at the very top of this file, we now use `TreeDerivation.generate_subderivation` with the `hom_step` generator to obtain the branch in the tree that yields the result `FactSet` for which the combined `GroundTermMapping`s form a homomorphism into the target model. -/
-public theorem chaseTreeResultIsUniversal (ct : RegularChaseTree obs kb) : ∀ (m : FactSet sig), m.modelsKb kb ->
-    ∃ (fs : FactSet sig) (h : GroundTermMapping sig), fs ∈ ct.result ∧ h.isHomomorphism fs m := by
-  have trg_inactive_of_fresh_term_present : ∀ (node : ct.NodeWithAddress) (trg : RTrigger obs kb.rules) i lt t, t ∈ trg.val.fresh_terms_for_head_disjunct i lt -> t ∈ (RegularChaseNode.regularChaseNodeInstance.outgoingFacts node.node).terms -> ¬ trg.val.active (RegularChaseNode.regularChaseNodeInstance.outgoingFacts node.node) := by
-    intro node trg i lt t t_fresh t_mem_node trg_act
-    apply trg_act.right
-    apply obs.contains_trg_result_implies_cond ⟨i, by simpa using lt⟩
-    exact RegularChaseTree.result_of_trigger_introducing_functional_term_occurs_in_chase node t_mem_node t_fresh
-
-  intro m m_is_model
-
+/-- We define the first InductiveHomomorphismResult to be used in the following infinite construction. -/
+noncomputable def start_for_infinite_list_of_derivations_and_homomorphisms
+    (ct : ChaseTree N obs kb)
+    (m : FactSet sig)
+    (m_is_model : m.modelsKb kb) :
+    InductiveHomomorphismResult ct m :=
   let start : InductiveHomomorphismResult ct m := ⟨(TreeDerivation.NodeWithAddress.root ct.toTreeDerivation, id), by
     simp only [TreeDerivation.NodeWithAddress.root]; rw [ct.database_first'.right.left]
     constructor
@@ -294,10 +296,19 @@ public theorem chaseTreeResultIsUniversal (ct : RegularChaseTree obs kb) : ∀ (
       have : f = e := by have hfr := hf.right; rw [hfr]; simp [TermMapping.apply_generalized_atom]
       rw [this] at hf
       exact hf.left⟩
+  start
 
-  let derivs_with_homs : PossiblyInfiniteList (RegularChaseDerivation obs kb.rules × GroundTermMapping sig) :=
-    PossiblyInfiniteList.generate start (hom_step RegularChaseNode.out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present) (fun res =>
-      let deriv : RegularChaseDerivation obs kb.rules := ct.generate_subderivation res (hom_step RegularChaseNode.out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present)
+/-- We use the inductive constructor to generate an infinite list of derivations together with their respective homomorphisms. -/
+noncomputable def infinite_list_of_derivations_and_homomorphisms
+    (out_sub_in : CN.out_sub_in)
+    (ct : ChaseTree N obs kb)
+    (m : FactSet sig)
+    (m_is_model : m.modelsKb kb)
+    (trg_inactive_of_fresh_term_present : ∀ (node : ct.NodeWithAddress) (trg : RTrigger obs kb.rules) i lt t, t ∈ trg.val.fresh_terms_for_head_disjunct i lt -> t ∈ (CN.outgoingFacts node.node).terms -> ¬ trg.val.active (CN.outgoingFacts node.node)) :
+    PossiblyInfiniteList (ChaseDerivation N obs kb.rules × GroundTermMapping sig) :=
+  let derivs_with_homs : PossiblyInfiniteList (ChaseDerivation N obs kb.rules × GroundTermMapping sig) :=
+    PossiblyInfiniteList.generate (start_for_infinite_list_of_derivations_and_homomorphisms ct m m_is_model) (hom_step out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present) (fun res =>
+      let deriv : ChaseDerivation N obs kb.rules := ct.generate_subderivation res (hom_step out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present)
         (fun res => res.val.fst)
         (by intro prev res res_mem; exact mem_childNodes_of_mem_hom_step res res_mem)
         (by intro prev eq_none
@@ -308,42 +319,96 @@ public theorem chaseTreeResultIsUniversal (ct : RegularChaseTree obs kb) : ∀ (
             exact this)
       (deriv, res.val.snd)
     )
+  derivs_with_homs
 
-  have derivs_with_homs_properties : ∀ step ∈ derivs_with_homs, step.snd.isHomomorphism step.fst.head.facts m := by
-    intro step step_mem
-    simp only [derivs_with_homs, PossiblyInfiniteList.mem_iff, PossiblyInfiniteList.get?_generate, Option.map_eq_some_iff] at step_mem
-    rw [← RegularChaseNode.outgoingFacts_eq]
-    grind
+/-- In every step of the infinite list, the associated mapping is indeed a homomorphism from the step's derivation to the target model. -/
+theorem each_step_isHomomorphism_in_infinite_list_of_derivations_and_homomorphisms
+    {out_sub_in : CN.out_sub_in}
+    {ct : ChaseTree N obs kb}
+    {m : FactSet sig}
+    {m_is_model : m.modelsKb kb}
+    {trg_inactive_of_fresh_term_present : ∀ (node : ct.NodeWithAddress) (trg : RTrigger obs kb.rules) i lt t, t ∈ trg.val.fresh_terms_for_head_disjunct i lt -> t ∈ (CN.outgoingFacts node.node).terms -> ¬ trg.val.active (CN.outgoingFacts node.node)} :
+    ∀ step ∈ infinite_list_of_derivations_and_homomorphisms out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present,
+    step.snd.isHomomorphism (CN.outgoingFacts step.fst.head) m := by
+  intro step step_mem
+  simp only [infinite_list_of_derivations_and_homomorphisms, PossiblyInfiniteList.mem_iff, PossiblyInfiniteList.get?_generate, Option.map_eq_some_iff] at step_mem
+  grind
 
-  let deriv := (derivs_with_homs.head.get (by simp [derivs_with_homs, PossiblyInfiniteList.head_generate])).fst
-  have deriv_mem : deriv ∈ ct.branches := by
-    simp only [deriv, derivs_with_homs, PossiblyInfiniteList.head_generate, Option.map_some, Option.get_some]
-    apply ct.generate_subderivation_mem_branches
-    rfl
+/-- The infinite list always has a first element that we unwrap here. -/
+noncomputable def head_infinite_list_of_derivations_and_homomorphisms
+    (out_sub_in : CN.out_sub_in)
+    (ct : ChaseTree N obs kb)
+    (m : FactSet sig)
+    (m_is_model : m.modelsKb kb)
+    (trg_inactive_of_fresh_term_present : ∀ (node : ct.NodeWithAddress) (trg : RTrigger obs kb.rules) i lt t, t ∈ trg.val.fresh_terms_for_head_disjunct i lt -> t ∈ (CN.outgoingFacts node.node).terms -> ¬ trg.val.active (CN.outgoingFacts node.node)) :
+    (ChaseDerivation N obs kb.rules × GroundTermMapping sig) :=
+  (infinite_list_of_derivations_and_homomorphisms out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present).head.get (by simp [infinite_list_of_derivations_and_homomorphisms, PossiblyInfiniteList.head_generate])
 
-  let branch := ct.chaseBranch_for_branch deriv_mem
+/-- The first derivation in the generated list is a branch in the chase tree. -/
+theorem mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms
+    {out_sub_in : CN.out_sub_in}
+    {ct : ChaseTree N obs kb}
+    {m : FactSet sig}
+    {m_is_model : m.modelsKb kb}
+    {trg_inactive_of_fresh_term_present : ∀ (node : ct.NodeWithAddress) (trg : RTrigger obs kb.rules) i lt t, t ∈ trg.val.fresh_terms_for_head_disjunct i lt -> t ∈ (CN.outgoingFacts node.node).terms -> ¬ trg.val.active (CN.outgoingFacts node.node)} :
+    (head_infinite_list_of_derivations_and_homomorphisms out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present).fst ∈ ct.branches := by
+  simp only [head_infinite_list_of_derivations_and_homomorphisms, infinite_list_of_derivations_and_homomorphisms, PossiblyInfiniteList.head_generate, Option.map_some, Option.get_some]
+  apply ct.generate_subderivation_mem_branches
+  rfl
 
-  have deriv_eq : deriv.branch = derivs_with_homs.map (fun step => step.fst.head) := by
-    let pairs : PossiblyInfiniteList (InductiveHomomorphismResult ct m) :=
-      PossiblyInfiniteList.generate start (hom_step RegularChaseNode.out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present) id
-    have pairs_eq : pairs.map (fun res => res.val.fst.node) = derivs_with_homs.map (fun step => step.fst.head) := by
-      simp only [pairs, derivs_with_homs]
-      apply PossiblyInfiniteList.ext; intro n
-      simp only [PossiblyInfiniteList.get?_map, PossiblyInfiniteList.get?_generate, Option.map_map]
-      apply Option.map_congr
-      simp
-    rw [← pairs_eq]
+/-- The first derivation in the generated list is equal to taking the heads of each derivation. -/
+theorem fst_head_infinite_list_of_derivations_and_homomorphisms_eq_list_of_all_heads
+    {out_sub_in : CN.out_sub_in}
+    {ct : ChaseTree N obs kb}
+    {m : FactSet sig}
+    {m_is_model : m.modelsKb kb}
+    {trg_inactive_of_fresh_term_present : ∀ (node : ct.NodeWithAddress) (trg : RTrigger obs kb.rules) i lt t, t ∈ trg.val.fresh_terms_for_head_disjunct i lt -> t ∈ (CN.outgoingFacts node.node).terms -> ¬ trg.val.active (CN.outgoingFacts node.node)} :
+    (head_infinite_list_of_derivations_and_homomorphisms out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present).fst.branch =
+    (infinite_list_of_derivations_and_homomorphisms out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present).map (fun step => step.fst.head) := by
+  let pairs : PossiblyInfiniteList (InductiveHomomorphismResult ct m) :=
+    PossiblyInfiniteList.generate (start_for_infinite_list_of_derivations_and_homomorphisms ct m m_is_model) (hom_step out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present) id
+  have pairs_eq : pairs.map (fun res => res.val.fst.node) = (infinite_list_of_derivations_and_homomorphisms out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present).map (fun step => step.fst.head) := by
+    simp only [pairs, infinite_list_of_derivations_and_homomorphisms]
     apply PossiblyInfiniteList.ext; intro n
-    rw [PossiblyInfiniteList.get?_map]
-    simp only [pairs, deriv, derivs_with_homs]
-    simp only [PossiblyInfiniteList.head_generate, Option.map_some, Option.get_some]
-    simp only [TreeDerivation.generate_subderivation, TreeDerivation.generate_branch, TreeDerivation.derivation_for_branch, FiniteDegreeTree.get?_generate_branch]
-    simp only [PossiblyInfiniteList.get?_generate, Option.map_map]
+    simp only [PossiblyInfiniteList.get?_map, PossiblyInfiniteList.get?_generate, Option.map_map]
     apply Option.map_congr
-    intro _ _
-    simp only [Function.comp_apply, id_eq]
-    simp only [TreeDerivation.toFiniteDegreeTreeWithRoot]
-    rw [← TreeDerivation.root.eq_def, TreeDerivation.NodeWithAddress.root_subderivation']
+    simp
+  rw [← pairs_eq]
+  apply PossiblyInfiniteList.ext; intro n
+  rw [PossiblyInfiniteList.get?_map]
+  simp only [pairs, head_infinite_list_of_derivations_and_homomorphisms, infinite_list_of_derivations_and_homomorphisms]
+  simp only [PossiblyInfiniteList.head_generate, Option.map_some, Option.get_some]
+  simp only [TreeDerivation.generate_subderivation, TreeDerivation.generate_branch, TreeDerivation.derivation_for_branch, FiniteDegreeTree.get?_generate_branch]
+  simp only [PossiblyInfiniteList.get?_generate, Option.map_map]
+  apply Option.map_congr
+  intro _ _
+  simp only [Function.comp_apply, id_eq]
+  simp only [TreeDerivation.toFiniteDegreeTreeWithRoot]
+  rw [← TreeDerivation.root.eq_def, TreeDerivation.NodeWithAddress.root_subderivation']
+
+end AuxiliaryDefsAndTheoremsForUniversalityProof
+
+namespace RegularChaseTree
+
+variable {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig}
+
+open AuxiliaryDefsAndTheoremsForUniversalityProof
+
+/-- As outlined at the very top of this file, we now use `TreeDerivation.generate_subderivation` with the `hom_step` generator to obtain the branch in the tree that yields the result `FactSet` for which the combined `GroundTermMapping`s form a homomorphism into the target model. -/
+theorem universal_result (ct : RegularChaseTree obs kb) : ∀ (m : FactSet sig), m.modelsKb kb ->
+    ∃ (fs : FactSet sig) (h : GroundTermMapping sig), fs ∈ ct.result ∧ h.isHomomorphism fs m := by
+
+  have trg_inactive_of_fresh_term_present : ∀ (node : ct.NodeWithAddress) (trg : RTrigger obs kb.rules) i lt t, t ∈ trg.val.fresh_terms_for_head_disjunct i lt -> t ∈ (RegularChaseNode.regularChaseNodeInstance.outgoingFacts node.node).terms -> ¬ trg.val.active (RegularChaseNode.regularChaseNodeInstance.outgoingFacts node.node) := by
+    intro node trg i lt t t_fresh t_mem_node trg_act
+    apply trg_act.right
+    apply obs.contains_trg_result_implies_cond ⟨i, by simpa using lt⟩
+    exact RegularChaseTree.result_of_trigger_introducing_functional_term_occurs_in_chase node t_mem_node t_fresh
+
+  intro m m_is_model
+
+  let derivs_with_homs := infinite_list_of_derivations_and_homomorphisms RegularChaseNode.out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present
+  let deriv := (head_infinite_list_of_derivations_and_homomorphisms RegularChaseNode.out_sub_in ct m m_is_model trg_inactive_of_fresh_term_present).fst
+  let branch := ct.chaseBranch_for_branch (branch := deriv) mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms
 
   have homs_extend_each_other : ∀ n, ∀ step ∈ derivs_with_homs.get? n, ∀ step2 ∈ derivs_with_homs.drop n,
       ∀ t ∈ step.fst.head.facts.terms, step.snd t = step2.snd t := by
@@ -356,7 +421,7 @@ public theorem chaseTreeResultIsUniversal (ct : RegularChaseTree obs kb) : ∀ (
       rcases ih with ⟨head, head_mem, ih⟩
       rw [ih]
       rw [PossiblyInfiniteList.IsSuffix_iff] at suffix; rcases suffix with ⟨m, suffix⟩
-      simp only [derivs_with_homs] at suffix
+      simp only [derivs_with_homs, infinite_list_of_derivations_and_homomorphisms] at suffix
       simp only [← suffix, PossiblyInfiniteList.head_drop, PossiblyInfiniteList.get?_drop] at head_mem
       simp only [← suffix, PossiblyInfiniteList.tail_drop, PossiblyInfiniteList.head_drop, PossiblyInfiniteList.get?_drop, Nat.add_succ] at next_mem
       rw [PossiblyInfiniteList.get?_generate, Option.mem_def, Option.map_eq_some_iff] at head_mem
@@ -370,12 +435,13 @@ public theorem chaseTreeResultIsUniversal (ct : RegularChaseTree obs kb) : ∀ (
       apply FactSet.terms_subset_of_subset _ _ t_mem
       have step_mem_deriv : deriv.branch.get? n = some step.fst.head := by
         rw [← PossiblyInfiniteList.head_drop]
-        rw [deriv_eq, PossiblyInfiniteList.head_drop, PossiblyInfiniteList.get?_map, step_mem]
+        rw [fst_head_infinite_list_of_derivations_and_homomorphisms_eq_list_of_all_heads]
+        rw [PossiblyInfiniteList.head_drop, PossiblyInfiniteList.get?_map, step_mem]
         simp
       let node1 : deriv.Node := ⟨step.fst.head, by exists n⟩
       have pair_mem_deriv : deriv.branch.get? (n+m) = some pair.val.fst.node := by
-        rw [deriv_eq]
-        simp only [derivs_with_homs, PossiblyInfiniteList.get?_map, PossiblyInfiniteList.get?_generate]
+        rw [fst_head_infinite_list_of_derivations_and_homomorphisms_eq_list_of_all_heads]
+        simp only [infinite_list_of_derivations_and_homomorphisms, PossiblyInfiniteList.get?_map, PossiblyInfiniteList.get?_generate]
         rw [pair_mem]
         simp
       let node2 : deriv.Node := ⟨pair.val.fst.node, by exists (n + m)⟩
@@ -427,19 +493,21 @@ public theorem chaseTreeResultIsUniversal (ct : RegularChaseTree obs kb) : ∀ (
   have global_h_hom : ∀ node ∈ deriv, global_h.applyFactSet node.facts ⊆ m := by
     intro node node_mem
     have node_mem : node ∈ deriv.branch := node_mem
-    rw [deriv_eq, PossiblyInfiniteList.mem_map] at node_mem
+    rw [fst_head_infinite_list_of_derivations_and_homomorphisms_eq_list_of_all_heads] at node_mem
+    rw [PossiblyInfiniteList.mem_map] at node_mem
     rcases node_mem with ⟨step, step_mem, node_mem⟩
     intro f'
     rw [GroundTermMapping.mem_applyFactSet]
     intro ⟨f, f_mem, f'_eq⟩
     rw [← node_mem] at f_mem
     rw [f'_eq, global_h_eq_each_hom step step_mem f f_mem]
-    apply (derivs_with_homs_properties _ step_mem).right
+    apply (each_step_isHomomorphism_in_infinite_list_of_derivations_and_homomorphisms _ step_mem).right
     apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_set
     exact f_mem
 
   exists RegularChaseBranch.result branch, global_h; constructor
-  . unfold RegularChaseBranch.result RegularChaseTree.result RegularTreeDerivation.result; rw [Set.mem_map]; exists deriv
+  . unfold RegularChaseBranch.result RegularChaseTree.result RegularTreeDerivation.result; rw [Set.mem_map]
+    exists deriv; constructor; exact mem_branches_fst_head_infinite_list_of_derivations_and_homomorphisms; rfl
   constructor
   . intro c
     simp only [global_h]
@@ -447,7 +515,7 @@ public theorem chaseTreeResultIsUniversal (ct : RegularChaseTree obs kb) : ∀ (
     case isFalse _ => rfl
     case isTrue t_mem_true =>
       have ⟨step_mem, _⟩ := Classical.choose_spec t_mem_true
-      apply (derivs_with_homs_properties _ step_mem).left
+      apply (each_step_isHomomorphism_in_infinite_list_of_derivations_and_homomorphisms _ step_mem).left
   . intro f'
     rw [GroundTermMapping.mem_applyFactSet]
     intro ⟨f, ⟨node, node_mem, f_mem⟩, f'_eq⟩
@@ -455,4 +523,6 @@ public theorem chaseTreeResultIsUniversal (ct : RegularChaseTree obs kb) : ∀ (
     apply global_h_hom node node_mem
     apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_set
     exact f_mem
+
+end RegularChaseTree
 


### PR DESCRIPTION
Since we already introduced `CoreChaseBranch`es and generalized much of our underlying machinery to be able to do so, it is only a natural and not very big step to introduce `CoreChaseTree`s accordingly.
As one would expect, they are simply `ChaseTree`s that use `CoreChaseNode`s.

Having `CoreChaseTree`s available, we also exchange the proof for showing that the `CoreChaseBranch` result is universal.
This now works as for the `RegularChaseBranch`: we only show the result for a tree and then prove that a deterministic chase is essentially equal to the single branch in a chase tree.
To this aim, parts of the universality construction that was hardcoded in the result for `RegularChaseTree`s has been extracted into generalized auxiliary theorems. This makes the proof of `CoreChaseTree.universal_result` very convenient.