### PR TITLE
Define head choices and general overapproximations for RPC

### DIFF
--- a/ExistentialRules/AlternativeMatches/Basic.lean
+++ b/ExistentialRules/AlternativeMatches/Basic.lean
@@ -26,7 +26,7 @@ namespace GroundTermMapping
 def isAlternativeMatch (h_alt : GroundTermMapping sig) (trg : PreTrigger sig) (i : Nat) (lt : i < trg.rule.head.length) (fs : FactSet sig) : Prop :=
   have _lt' : i < trg.mapped_head.length := by grind
   (h_alt.isHomomorphism trg.mapped_head[i].toSet fs) ∧
-  (∀ t, t ∈ trg.rule.frontier.map trg.subs -> h_alt t = t) ∧
+  (∀ t, t ∈ trg.mapped_frontier -> h_alt t = t) ∧
   (∃ t, (t ∈ trg.fresh_terms_for_head_disjunct i lt) ∧
         (¬ t ∈ (trg.fresh_terms_for_head_disjunct i lt).map h_alt))
 
@@ -96,9 +96,7 @@ theorem alternativeMatch_of_satisfied
         rw [GroundTerm.functionSymbol_func]
       | inr v_not_exis =>
         have v_in_frontier : v ∈ trg.rule.frontier := by
-          unfold Rule.existential_vars_for_head_disjunct at v_not_exis
-          rw [List.mem_filter, not_and, decide_not, not_decide_eq_true, Decidable.not_not] at v_not_exis
-          apply v_not_exis
+          apply Rule.mem_frontier_of_mem_head_disjunct_of_not_mem_existential_vars _ _ v_not_exis
           rw [FunctionFreeConjunction.mem_vars]; exists a
         simp only [PreTrigger.subs_for_mapped_head, PreTrigger.apply_to_var_or_const_of_not_mem_existential_vars _ _ _ _ v_not_exis]
         rw [s_frontier _ v_in_frontier]

--- a/ExistentialRules/AlternativeMatches/Chase.lean
+++ b/ExistentialRules/AlternativeMatches/Chase.lean
@@ -109,17 +109,12 @@ theorem result_isWeakCore_of_noAltMatch {cb : RegularChaseBranch obs kb} (det : 
 
       let trg_res_terms := (FactSet.terms ((RegularChaseNode.regularChaseNodeInstance.origin_result next) origin_isSome).toSet)
 
-      have identity_frontier : ∀ t ∈ List.map (next.origin.get origin_isSome).fst.val.subs (next.origin.get origin_isSome).fst.val.rule.frontier, h_k t = t := by
+      have identity_frontier : ∀ t ∈ (next.origin.get origin_isSome).fst.val.mapped_frontier, h_k t = t := by
         intro t t_mem
         apply identity
-        rw [List.mem_map] at t_mem
-        rcases t_mem with ⟨v, v_mem, v_eq⟩
         apply FactSet.terms_subset_of_subset origin_trg_active.left
-        rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
-        apply Or.inr
-        exists v; constructor
-        . exact Rule.frontier_subset_vars_body v_mem
-        . exact v_eq
+        rw [FactSet.mem_terms_toSet]
+        exact PreTrigger.mem_terms_mapped_body_of_mem_mapped_frontier _ t_mem
 
       have h_surj_on_trg_res : h_k.surjectiveSet trg_res_terms trg_res_terms := by
         apply Classical.byContradiction
@@ -156,6 +151,7 @@ theorem result_isWeakCore_of_noAltMatch {cb : RegularChaseBranch obs kb} (det : 
             apply False.elim; apply no_arg_for_t_with_t
             apply identity_frontier
             rw [List.mem_map] at t_mem
+            unfold PreTrigger.mapped_frontier
             rw [List.mem_map]
             rcases t_mem with ⟨v, v_mem, t_mem⟩
             exists v; constructor
@@ -352,8 +348,8 @@ theorem non_id_endomorphism_of_altMatch {cb : RegularChaseBranch obs kb} (det : 
         | inr t_mem =>
         cases t_mem with
         | inl t_mem =>
-          have t_mem : t ∈ (next.origin.get (cd.isSome_origin_next next_mem)).fst.val.rule.frontier.map (next.origin.get (cd.isSome_origin_next next_mem)).fst.val.subs := by
-            rw [List.mem_map] at t_mem; rw [List.mem_map]; rcases t_mem with ⟨v, v_mem, t_mem⟩; exists v; constructor
+          have t_mem : t ∈ (next.origin.get (cd.isSome_origin_next next_mem)).fst.val.mapped_frontier := by
+            rw [List.mem_map] at t_mem; unfold PreTrigger.mapped_frontier; rw [List.mem_map]; rcases t_mem with ⟨v, v_mem, t_mem⟩; exists v; constructor
             . rw [Rule.mem_frontier_iff_mem_frontier_for_head]; exact ⟨_, ⟨_, v_mem⟩⟩
             . exact t_mem
           unfold h; split <;> simp [altMatch.right.left _ t_mem]
@@ -514,13 +510,8 @@ theorem altMatch_of_some_not_reaches_self (cb : RegularChaseBranch obs kb) (fs :
       apply h.repeat_cycle_mul
       apply hom_id
       apply FactSet.terms_subset_of_subset (cd2.active_trigger_origin_next next_eq).left
-      rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
-      apply Or.inr
-      rw [List.mem_map] at t_mem
-      rcases t_mem with ⟨v, v_mem, t_mem⟩
-      exists v; constructor
-      . apply Rule.frontier_subset_vars_body; exact v_mem
-      . exact t_mem
+      rw [FactSet.mem_terms_toSet]
+      exact PreTrigger.mem_terms_mapped_body_of_mem_mapped_frontier _ t_mem
     . exists t
       constructor
       . have t_mem' := t_mem

--- a/ExistentialRules/AlternativeMatches/HomomorphismExtension.lean
+++ b/ExistentialRules/AlternativeMatches/HomomorphismExtension.lean
@@ -93,9 +93,7 @@ noncomputable def extend_hom_to_next_step_of_next_eq_some
       simp only [subs, subs_frontier _ v_frontier]
       rfl
     | inr v_frontier =>
-      have v_exis : v ∈ origin.fst.val.rule.existential_vars_for_head_disjunct disj.val disj.isLt := by
-        simp only [Rule.existential_vars_for_head_disjunct, List.mem_filter, decide_eq_true_iff]
-        exact ⟨v_mem, v_frontier⟩
+      have v_exis := Rule.mem_existential_vars_of_mem_head_disjunct_of_not_mem_frontier _ v_mem v_frontier
       rw [origin.fst.val.apply_to_var_or_const_of_mem_existential_vars _ _ _ v_exis]
       simp only [h', origin.fst.val.mem_fresh_terms_of_functional_for_exis_var, ↓reduceDIte]
       rw [PreTrigger.existential_var_for_fresh_term_after_functional_term_for_var]

--- a/ExistentialRules/AtomsAndRules/FactSet.lean
+++ b/ExistentialRules/AtomsAndRules/FactSet.lean
@@ -97,6 +97,15 @@ theorem mem_constants_toSet {l : List (Fact sig)} : ∀ c, c ∈ FactSet.constan
   intro t; rw [List.mem_flatMap]
   constructor <;> (rintro ⟨f, f_mem, t_mem⟩; exists f; grind)
 
+/-- A constant occurs in the fact set iff it occurs as a constant in one of its terms. -/
+theorem mem_constants_iff_mem_terms {fs : FactSet sig} : ∀ {c}, c ∈ fs.constants ↔ ∃ t ∈ fs.terms, c ∈ t.constants := by
+  unfold constants terms Fact.constants
+  simp only [List.mem_flatMap]
+  intro c
+  constructor
+  . intro ⟨f, f_mem, ⟨t, t_mem, c_mem⟩⟩; exists t; constructor; exists f; exact c_mem
+  . intro ⟨t, ⟨f, f_mem, t_mem⟩, c_mem⟩; exists f; constructor; exact f_mem; exists t
+
 /-- The a `FactSet` is a subset of another, then their constants share this subset relation. -/
 @[grind ->]
 theorem constants_subset_of_subset {fs1 fs2 : FactSet sig} : fs1 ⊆ fs2 -> fs1.constants ⊆ fs2.constants := by

--- a/ExistentialRules/AtomsAndRules/Rule.lean
+++ b/ExistentialRules/AtomsAndRules/Rule.lean
@@ -119,5 +119,17 @@ theorem not_mem_frontier_of_mem_existential_vars_for_head_disjunct {r : Rule sig
     ∀ v ∈ r.existential_vars_for_head_disjunct i lt, v ∉ r.frontier := by
   grind [existential_vars_for_head_disjunct]
 
+/-- A variable that is in a head but not existential must be in the frontier. -/
+@[grind ->]
+theorem mem_frontier_of_mem_head_disjunct_of_not_mem_existential_vars {r : Rule sig} {i : Nat} {lt : i < r.head.length} :
+    ∀ v ∈ r.head[i].vars, v ∉ r.existential_vars_for_head_disjunct i lt -> v ∈ r.frontier := by
+  grind [existential_vars_for_head_disjunct]
+
+/-- A variable that is in a head but not in the frontier must be existential. -/
+@[grind ->]
+theorem mem_existential_vars_of_mem_head_disjunct_of_not_mem_frontier {r : Rule sig} {i : Nat} {lt : i < r.head.length} :
+    ∀ v ∈ r.head[i].vars, v ∉ r.frontier -> v ∈ r.existential_vars_for_head_disjunct i lt := by
+  grind [existential_vars_for_head_disjunct]
+
 end Rule
 

--- a/ExistentialRules/ChaseSequence.lean
+++ b/ExistentialRules/ChaseSequence.lean
@@ -14,6 +14,7 @@ import ExistentialRules.ChaseSequence.CoreChase
 import ExistentialRules.ChaseSequence.Universality
 import ExistentialRules.ChaseSequence.Deterministic
 import ExistentialRules.ChaseSequence.Nontermination.CondenseGenerator
+import ExistentialRules.ChaseSequence.Nontermination.HeadChoice
 import ExistentialRules.ChaseSequence.Nontermination.RpcLike
 import ExistentialRules.ChaseSequence.Nontermination.SparseSubderivationGenerator
 import ExistentialRules.ChaseSequence.Nontermination.Unblockability

--- a/ExistentialRules/ChaseSequence.lean
+++ b/ExistentialRules/ChaseSequence.lean
@@ -16,6 +16,7 @@ import ExistentialRules.ChaseSequence.Deterministic
 import ExistentialRules.ChaseSequence.Nontermination.CondenseGenerator
 import ExistentialRules.ChaseSequence.Nontermination.RpcLike
 import ExistentialRules.ChaseSequence.Nontermination.SparseSubderivationGenerator
+import ExistentialRules.ChaseSequence.Nontermination.Unblockability
 import ExistentialRules.ChaseSequence.Termination
 import ExistentialRules.ChaseSequence.TreeDerivation
 

--- a/ExistentialRules/ChaseSequence.lean
+++ b/ExistentialRules/ChaseSequence.lean
@@ -13,11 +13,7 @@ import ExistentialRules.ChaseSequence.ChaseTree
 import ExistentialRules.ChaseSequence.CoreChase
 import ExistentialRules.ChaseSequence.Universality
 import ExistentialRules.ChaseSequence.Deterministic
-import ExistentialRules.ChaseSequence.Nontermination.CondenseGenerator
-import ExistentialRules.ChaseSequence.Nontermination.HeadChoice
-import ExistentialRules.ChaseSequence.Nontermination.RpcLike
-import ExistentialRules.ChaseSequence.Nontermination.SparseSubderivationGenerator
-import ExistentialRules.ChaseSequence.Nontermination.Unblockability
+import ExistentialRules.ChaseSequence.Nontermination
 import ExistentialRules.ChaseSequence.Termination
 import ExistentialRules.ChaseSequence.TreeDerivation
 

--- a/ExistentialRules/ChaseSequence/ChaseDerivation.lean
+++ b/ExistentialRules/ChaseSequence/ChaseDerivation.lean
@@ -321,29 +321,10 @@ theorem constants_node_subset_constants_fs_union_constants_rules
         apply Or.inl
         rw [List.mem_flatMap] at c_mem
         rcases c_mem with ⟨t, t_mem, c_mem⟩
-        rw [List.mem_map] at t_mem
-        rcases t_mem with ⟨v, v_mem, t_mem⟩
-        rcases FunctionFreeConjunction.mem_vars.mp (origin.fst.val.rule.frontier_subset_vars_body v_mem) with ⟨a, a_mem, v_mem'⟩
-        exists origin.fst.val.subs.apply_function_free_atom a
-        constructor
-        . apply (cd2.active_trigger_origin_next next_mem).left
-          rw [List.mem_toSet]
-          apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_list
-          exact a_mem
-        . unfold Fact.constants
-          rw [List.mem_flatMap]
-          exists t
-          constructor
-          . unfold GroundSubstitution.apply_function_free_atom
-            unfold TermMapping.apply_generalized_atom
-            rw [List.mem_map]
-            exists VarOrConst.var v
-            constructor
-            . exact v_mem'
-            . unfold PreTrigger.subs_for_mapped_head at t_mem
-              rw [PreTrigger.apply_to_var_or_const_frontier_var _ _ _ _ v_mem] at t_mem
-              exact t_mem
-          . exact c_mem
+        apply FactSet.constants_subset_of_subset (cd2.active_trigger_origin_next next_mem).left
+        rw [FactSet.mem_constants_iff_mem_terms]; exists t; constructor
+        . rw [FactSet.mem_terms_toSet]; apply PreTrigger.mem_terms_mapped_body_of_mem_mapped_frontier; exact t_mem
+        . exact c_mem
       | inr c_mem =>
         apply Or.inr
         exists origin.fst.val.rule

--- a/ExistentialRules/ChaseSequence/CoreChase/CoreChaseNode.lean
+++ b/ExistentialRules/ChaseSequence/CoreChase/CoreChaseNode.lean
@@ -69,7 +69,7 @@ This is helpful for the `CoreChaseNode` later on as each node features a `homSub
 /-- If a trigger is satisfied for fs and all of its frontier terms still occur in a finite core homSubset of fs, then the trigger is also satisfied in this homSubset. -/
 theorem trg_remains_obsolete_of_isWeakCore_of_homSubset_of_finite
     {fs core : FactSet sig} (wc : core.isWeakCore) (homSub : core.homSubset fs) (fin : core.finite) :
-    ∀ (trg : PreTrigger sig), trg.satisfied fs -> (trg.rule.frontier.map trg.subs).toSet ⊆ core.terms -> trg.satisfied core := by
+    ∀ (trg : PreTrigger sig), trg.satisfied fs -> trg.mapped_frontier.toSet ⊆ core.terms -> trg.satisfied core := by
   intro trg trg_sat frontier_in_core
 
   rcases trg_sat with ⟨idx, lt, trg_sat⟩
@@ -104,12 +104,10 @@ theorem equiv_trg_obsolete_of_isWeakCore_of_homSubset_of_finite
   intro trg trg_sat trg2 equiv trg2_loaded
   rw [← PreTrigger.satisfied_preserved_of_equiv equiv]
   apply trg_remains_obsolete_of_isWeakCore_of_homSubset_of_finite wc homSub fin trg trg_sat
-  rw [equiv.left]
-  intro t t_mem; apply FactSet.terms_subset_of_subset trg2_loaded
-  rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
-  apply Or.inr; rw [List.mem_toSet, List.mem_map] at t_mem; rcases t_mem with ⟨v, v_mem, t_eq⟩
-  exists v; constructor; apply Rule.frontier_subset_vars_body; exact v_mem
-  rw [← equiv.left] at v_mem; rw [← equiv.right _ v_mem]; exact t_eq
+  rw [trg.mapped_frontier_eq_of_equiv equiv]
+  apply Set.subset_trans _ (FactSet.terms_subset_of_subset trg2_loaded)
+  intro t t_mem; rw [List.mem_toSet] at t_mem; rw [FactSet.mem_terms_toSet]
+  exact trg2.mem_terms_mapped_body_of_mem_mapped_frontier _ t_mem
 
 end AuxiliaryResultsForTriggerSatisfaction
 

--- a/ExistentialRules/ChaseSequence/Nontermination.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination.lean
@@ -1,0 +1,13 @@
+/-
+Copyright 2026 Lukas Gerlach
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+module
+
+import ExistentialRules.ChaseSequence.Nontermination.CondenseGenerator
+import ExistentialRules.ChaseSequence.Nontermination.HeadChoice
+import ExistentialRules.ChaseSequence.Nontermination.RpcLike
+import ExistentialRules.ChaseSequence.Nontermination.SparseSubderivationGenerator
+import ExistentialRules.ChaseSequence.Nontermination.Unblockability
+

--- a/ExistentialRules/ChaseSequence/Nontermination/CondenseGenerator.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/CondenseGenerator.lean
@@ -15,6 +15,9 @@ import BasicLeanDatastructures.WellFounded
 Here we introduce functionality that allows to condense repeated function calls according to a certain mapper.
 By that, we mean that if the generator produces a new value that is the same as the previous one under the mapper function, then the value is skipped.
 
+LOOKS LIKE WITH HEAD CHOICES INVOLVED, WE ACTUALLY DO NOT NEED THIS ANYMORE.
+MAYBE THIS IS STILL USEFUL AS GENERAL MACHINERY BUT THEN IT SHOULD MOVED TO SOME OTHER PLACE EVENTUALLY.
+
 -/
 
 namespace Function

--- a/ExistentialRules/ChaseSequence/Nontermination/HeadChoice.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/HeadChoice.lean
@@ -21,12 +21,31 @@ abbrev HeadChoice (sig : Signature) [DecidableEq sig.P] [DecidableEq sig.C] [Dec
 
 variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
 
-/-- A `ChaseDerivationSkeleton` adheres to a `HeadChoice` if every origin uses the index that is the head choice of its trigger. -/
+/-- A shortcut for the trigger output dictaded by a head choice. -/
+def PreTrigger.output_for_headChoice (trg : PreTrigger sig) (hc : HeadChoice sig) : List (Fact sig) :=
+  trg.mapped_head[(hc trg).val]
+
+namespace ChaseNode
+
+variable {obs : ObsolescenceCondition sig} {rules : RuleSet sig} {N : Type u} [CN : ChaseNode N obs rules]
+
+/-- A `ChaseNode` adheres to a `HeadChoice` if its origin uses the index that is the head choice of its trigger. -/
+def adheres_to_headChoice (node : N) (hc : HeadChoice sig) : Prop :=
+  ∀ orig ∈ (CN.origin node), orig.snd.val = (hc orig.fst.val).val
+
+theorem origin_result_eq_of_adheres_to_headChoice {node : N} (isSome : (CN.origin node).isSome)
+    {hc : HeadChoice sig} (adheres : CN.adheres_to_headChoice node hc) :
+    CN.origin_result node isSome = ((CN.origin node).get isSome).fst.val.output_for_headChoice hc := by
+  rw [CN.origin_result_eq isSome rfl (by apply Eq.symm; apply adheres; simp)]; rfl
+
+end ChaseNode
+
+/-- A `ChaseDerivationSkeleton` adheres to a `HeadChoice` if every node adheres to the `HeadChoice`. -/
 @[expose]
 def ChaseDerivationSkeleton.adheres_to_headChoice
     {obs : ObsolescenceCondition sig} {rules : RuleSet sig} {N : Type u} [CN : ChaseNode N obs rules]
     (cd : ChaseDerivationSkeleton N obs rules) (hc : HeadChoice sig) : Prop :=
-  ∀ n ∈ cd, ∀ orig ∈ (CN.origin n), orig.snd = hc orig.fst.val
+  ∀ n ∈ cd, CN.adheres_to_headChoice n hc
 
 namespace TreeDerivation
 

--- a/ExistentialRules/ChaseSequence/Nontermination/HeadChoice.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/HeadChoice.lean
@@ -1,0 +1,105 @@
+/-
+Copyright 2026 Lukas Gerlach
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+module
+
+public import ExistentialRules.ChaseSequence.ChaseTree
+
+/-!
+# HeadChoice
+
+Here we define `HeadChoice`s, which are merely functions from triggers to head indices.
+We also define machinery to get a branch from a tree that corresponds to a given `HeadChoice`.
+-/
+
+public section
+
+/-- A `HeadChoice` is a function that maps each trigger to one of its head indices. -/
+abbrev HeadChoice (sig : Signature) [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V] := (trg : PreTrigger sig) -> Fin trg.rule.head.length
+
+variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
+
+/-- A `ChaseDerivationSkeleton` adheres to a `HeadChoice` if every origin uses the index that is the head choice of its trigger. -/
+@[expose]
+def ChaseDerivationSkeleton.adheres_to_headChoice
+    {obs : ObsolescenceCondition sig} {rules : RuleSet sig} {N : Type u} [CN : ChaseNode N obs rules]
+    (cd : ChaseDerivationSkeleton N obs rules) (hc : HeadChoice sig) : Prop :=
+  ∀ n ∈ cd, ∀ orig ∈ (CN.origin n), orig.snd = hc orig.fst.val
+
+namespace TreeDerivation
+
+variable {obs : ObsolescenceCondition sig} {rules : RuleSet sig} {N : Type u} [CN : ChaseNode N obs rules]
+
+/-- The generator function used to generate the tree branch corresponding to the given `HeadChoice`. -/
+def generator_for_headChoice (td : TreeDerivation N obs rules) (hc : HeadChoice sig) (n : td.NodeWithAddress) : Option td.NodeWithAddress :=
+  let next_trg_opt : Option (PreTrigger sig) := (n.childNodes.head?.bind (fun c => CN.origin c.node)).map (fun o => o.fst.val)
+  next_trg_opt.bind (fun trg => n.childNodes[hc trg]?)
+
+/-- The generator function produces a child node if it produces a value at all. -/
+theorem generator_for_headChoice_mem_childNodes {td : TreeDerivation N obs rules} {hc : HeadChoice sig} (n : td.NodeWithAddress) :
+    ∀ next ∈ td.generator_for_headChoice hc n, next ∈ n.childNodes := by
+  intro next next_mem
+  simp only [generator_for_headChoice] at next_mem; rw [Option.mem_def, Option.bind_eq_some_iff] at next_mem
+  rcases next_mem with ⟨_, _, next_mem⟩
+  rw [List.mem_iff_getElem?]
+  exact ⟨_, next_mem⟩
+
+/-- The generator function does not yield a new value if and only if the childNodes are empty. -/
+theorem generator_for_headChoice_eq_none_iff_childNodes_eq_nil {td : TreeDerivation N obs rules} {hc : HeadChoice sig} (n : td.NodeWithAddress) :
+    td.generator_for_headChoice hc n = none ↔ n.childNodes = [] := by
+  simp only [generator_for_headChoice]
+  cases n.childNodes.instDecidableEqNil.em with
+  | inl eq_nil => simp [eq_nil]
+  | inr ne_nil =>
+    have ne_nil' : n.subderivation.childNodes ≠ [] := by rw [n.childNodes_eq_childNodes]; simp [ne_nil]
+    rcases n.triggers_exist ne_nil' with ⟨trg, act, ingoing_eq, trg_eq, orig_eq⟩
+    apply iff_of_false _ ne_nil
+    intro contra
+    simp only [Option.bind_eq_none_iff] at contra
+    specialize contra trg.val (by
+      rw [List.head?_eq_some_head ne_nil, Option.bind_some]
+      suffices (ChaseNode.origin (n.childNodes.head ne_nil).node).map (fun o => o.fst.val.toPreTrigger) = ((ChaseNode.origin (n.childNodes.head ne_nil).node).map (fun o => o.fst)).map (fun trg => trg.val.toPreTrigger) by
+        rw [this, trg_eq]
+        . simp
+        . rw [n.childNodes_eq_childNodes]; apply List.mem_map_of_mem; simp
+      simp; rfl)
+
+    suffices (hc trg.val).val < (n.subderivation.childNodes.map (ChaseNode.ingoingFacts obs rules)).length by
+      apply Nat.not_le_of_lt this; rw [n.childNodes_eq_childNodes]; simp only [List.length_map]; rw [← List.getElem?_eq_none_iff]; exact contra
+    rw [ingoing_eq, List.length_map, PreTrigger.length_mapped_head]; exact (hc trg.val).isLt
+
+/-- This function generates the tree branch that corresponds to the given `HeadChoice`. -/
+def subderivation_for_headChoice (td : TreeDerivation N obs rules) (hc : HeadChoice sig) : ChaseDerivation N obs rules :=
+  td.generate_subderivation (NodeWithAddress.root td) (td.generator_for_headChoice hc) id td.generator_for_headChoice_mem_childNodes (by intro n; rw [generator_for_headChoice_eq_none_iff_childNodes_eq_nil]; rw [List.eq_nil_iff_length_eq_zero, List.eq_nil_iff_length_eq_zero, n.length_childNodes, n.subderivation.childNodes_eq]; simp)
+
+/-- The `subderivation_for_headChoice` is a branch, which follows since we use `TreeDerivation.generate_subderivation` to build it. -/
+theorem subderivation_for_headChoice_mem_branches {td : TreeDerivation N obs rules} {hc : HeadChoice sig} :
+  td.subderivation_for_headChoice hc ∈ td.branches := by apply td.generate_subderivation_mem_branches; rfl
+
+/-- The head of `subderivation_for_headChoice` is the root of the tree derivation. -/
+theorem head_subderivation_for_headChoice {td : TreeDerivation N obs rules} {hc : HeadChoice sig} :
+  (td.subderivation_for_headChoice hc).head = td.root := td.head_generate_subderivation
+
+end TreeDerivation
+
+namespace ChaseTree
+
+variable {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig} {N : Type u} [CN : ChaseNode N obs kb.rules]
+
+/-- This function generates the tree branch that corresponds to the given `HeadChoice`. -/
+@[expose]
+def subderivation_for_headChoice (ct : ChaseTree N obs kb) (hc : HeadChoice sig) : ChaseBranch N obs kb :=
+  let deriv := ct.toTreeDerivation.subderivation_for_headChoice hc
+  {
+    branch := deriv.branch,
+    isSome_head := deriv.isSome_head,
+    triggers_exist := deriv.triggers_exist,
+    triggers_active := deriv.triggers_active,
+    fairness := deriv.fairness,
+    database_first := by rw [TreeDerivation.head_subderivation_for_headChoice]; exact ct.database_first
+  }
+
+end ChaseTree
+

--- a/ExistentialRules/ChaseSequence/Nontermination/HeadChoice.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/HeadChoice.lean
@@ -21,15 +21,26 @@ abbrev HeadChoice (sig : Signature) [DecidableEq sig.P] [DecidableEq sig.C] [Dec
 
 variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
 
+/-- Often we want to assume that a `HeadChoice` for equivalent triggers returns the same index. -/
+@[expose]
+def HeadChoice.consistent_for_equivalent_triggers (hc : HeadChoice sig) : Prop := ∀ {trg trg2 : PreTrigger sig}, trg.equiv trg2 -> (hc trg).val = (hc trg2).val
+
 /-- A shortcut for the trigger output dictaded by a head choice. -/
+@[expose]
 def PreTrigger.output_for_headChoice (trg : PreTrigger sig) (hc : HeadChoice sig) : List (Fact sig) :=
   trg.mapped_head[(hc trg).val]
+
+/-- The head choice output for equivalent triggers is the same given that the head choice is `consistent_for_equivalent_triggers`. -/
+theorem PreTrigger.output_for_headChoice_eq_of_equiv {trg trg2 : PreTrigger sig} {hc : HeadChoice sig}
+    (hc_consistent : hc.consistent_for_equivalent_triggers) (equiv : trg.equiv trg2) : trg.output_for_headChoice hc = trg2.output_for_headChoice hc := by
+  unfold output_for_headChoice; simp only [hc_consistent equiv, PreTrigger.result_eq_of_equiv equiv]
 
 namespace ChaseNode
 
 variable {obs : ObsolescenceCondition sig} {rules : RuleSet sig} {N : Type u} [CN : ChaseNode N obs rules]
 
 /-- A `ChaseNode` adheres to a `HeadChoice` if its origin uses the index that is the head choice of its trigger. -/
+@[expose]
 def adheres_to_headChoice (node : N) (hc : HeadChoice sig) : Prop :=
   ∀ orig ∈ (CN.origin node), orig.snd.val = (hc orig.fst.val).val
 
@@ -54,7 +65,7 @@ variable {obs : ObsolescenceCondition sig} {rules : RuleSet sig} {N : Type u} [C
 /-- The generator function used to generate the tree branch corresponding to the given `HeadChoice`. -/
 def generator_for_headChoice (td : TreeDerivation N obs rules) (hc : HeadChoice sig) (n : td.NodeWithAddress) : Option td.NodeWithAddress :=
   let next_trg_opt : Option (PreTrigger sig) := (n.childNodes.head?.bind (fun c => CN.origin c.node)).map (fun o => o.fst.val)
-  next_trg_opt.bind (fun trg => n.childNodes[hc trg]?)
+  next_trg_opt.bind (fun trg => n.childNodes[(hc trg).val]?)
 
 /-- The generator function produces a child node if it produces a value at all. -/
 theorem generator_for_headChoice_mem_childNodes {td : TreeDerivation N obs rules} {hc : HeadChoice sig} (n : td.NodeWithAddress) :
@@ -89,6 +100,27 @@ theorem generator_for_headChoice_eq_none_iff_childNodes_eq_nil {td : TreeDerivat
       apply Nat.not_le_of_lt this; rw [n.childNodes_eq_childNodes]; simp only [List.length_map]; rw [← List.getElem?_eq_none_iff]; exact contra
     rw [ingoing_eq, List.length_map, PreTrigger.length_mapped_head]; exact (hc trg.val).isLt
 
+/-- The node produced by `generator_for_headChoice` adheres to the head choice. -/
+theorem generator_for_headChoice_adheres_to_headChoice {td : TreeDerivation N obs rules} {hc : HeadChoice sig} (n : td.NodeWithAddress) :
+    ∀ next ∈ td.generator_for_headChoice hc n, CN.adheres_to_headChoice next.node hc := by
+  intro next next_mem orig orig_mem; simp only [generator_for_headChoice, Option.mem_def, Option.bind_eq_some_iff] at next_mem
+  rcases next_mem with ⟨head_trg, head_trg_eq, next_mem⟩
+  have childNodes_ne_nil : n.childNodes ≠ [] := by apply List.ne_nil_of_mem; rw [List.mem_iff_getElem?]; exact ⟨_, next_mem⟩
+  rcases n.triggers_exist (by rw [TreeDerivation.NodeWithAddress.childNodes_eq_childNodes]; intro contra; rw [List.map_eq_nil_iff] at contra; apply childNodes_ne_nil; exact contra) with ⟨trg, act, ingoing_eq, trg_eq, orig_eq⟩
+  specialize orig_eq (next.node, (hc head_trg).val) (by simp only [List.mem_zipIdx_iff_getElem?, TreeDerivation.NodeWithAddress.childNodes_eq_childNodes, List.getElem?_map]; rw [next_mem]; simp)
+  rw [Option.mem_def] at orig_mem
+  simp only [orig_mem, Option.map_some, Option.some_inj] at orig_eq
+  rw [orig_eq]
+  suffices head_trg = orig.fst.val by rw [this]
+  have trg_eq' := trg_eq next.node (by rw [TreeDerivation.NodeWithAddress.childNodes_eq_childNodes]; apply List.mem_map_of_mem; apply List.mem_of_getElem?; exact next_mem)
+  rw [orig_mem, Option.map_some, Option.some_inj] at trg_eq'
+  rw [trg_eq']
+  rw [List.head?_eq_some_head childNodes_ne_nil, Option.bind_some] at head_trg_eq
+  have trg_eq' := trg_eq (n.childNodes.head childNodes_ne_nil).node (by rw [TreeDerivation.NodeWithAddress.childNodes_eq_childNodes]; apply List.mem_map_of_mem; exact List.head_mem _)
+  rw [Option.map_eq_some_iff] at trg_eq'; rcases trg_eq' with ⟨head_orig, trg_eq'⟩
+  rw [trg_eq'.left, Option.map_some, Option.some_inj] at head_trg_eq
+  rw [← head_trg_eq, trg_eq'.right]
+
 /-- This function generates the tree branch that corresponds to the given `HeadChoice`. -/
 def subderivation_for_headChoice (td : TreeDerivation N obs rules) (hc : HeadChoice sig) : ChaseDerivation N obs rules :=
   td.generate_subderivation (NodeWithAddress.root td) (td.generator_for_headChoice hc) id td.generator_for_headChoice_mem_childNodes (by intro n; rw [generator_for_headChoice_eq_none_iff_childNodes_eq_nil]; rw [List.eq_nil_iff_length_eq_zero, List.eq_nil_iff_length_eq_zero, n.length_childNodes, n.subderivation.childNodes_eq]; simp)
@@ -100,6 +132,22 @@ theorem subderivation_for_headChoice_mem_branches {td : TreeDerivation N obs rul
 /-- The head of `subderivation_for_headChoice` is the root of the tree derivation. -/
 theorem head_subderivation_for_headChoice {td : TreeDerivation N obs rules} {hc : HeadChoice sig} :
   (td.subderivation_for_headChoice hc).head = td.root := td.head_generate_subderivation
+
+/-- The subderivation for a head choice adheres to that head choice. -/
+theorem subderivation_for_headChoice_adheres_to_headChoice_of_root_adheres {td : TreeDerivation N obs rules} {hc : HeadChoice sig} :
+    CN.adheres_to_headChoice td.root hc -> (td.subderivation_for_headChoice hc).adheres_to_headChoice hc := by
+  simp only [subderivation_for_headChoice]
+  intro root_adheres node node_mem; rw [← ChaseDerivation.mem_def, td.mem_generate_subderivation] at node_mem
+  rcases node_mem with ⟨n, node_mem⟩
+  cases n with
+  | zero => simp only [Function.repeat_zero, Option.map_some, Option.mem_some] at node_mem; rw [← node_mem]; exact root_adheres
+  | succ n =>
+    rw [Function.repeat_succ, Option.mem_def, Option.map_map, Option.map_eq_some_iff] at node_mem
+    rcases node_mem with ⟨next, next_mem, node_mem⟩
+    rw [Option.bind_eq_some_iff] at next_mem; rcases next_mem with ⟨_, _, goal⟩
+    rw [← node_mem]
+    apply generator_for_headChoice_adheres_to_headChoice
+    exact goal
 
 end TreeDerivation
 
@@ -119,6 +167,12 @@ def subderivation_for_headChoice (ct : ChaseTree N obs kb) (hc : HeadChoice sig)
     fairness := deriv.fairness,
     database_first := by rw [TreeDerivation.head_subderivation_for_headChoice]; exact ct.database_first
   }
+
+/-- The subderivation for a head choice adheres to that head choice. -/
+theorem subderivation_for_headChoice_adheres_to_headChoice {ct : ChaseTree N obs kb} {hc : HeadChoice sig} :
+    (ct.subderivation_for_headChoice hc).adheres_to_headChoice hc := by
+  apply TreeDerivation.subderivation_for_headChoice_adheres_to_headChoice_of_root_adheres
+  intro orig orig_mem; rw [ct.database_first.right.right] at orig_mem; simp at orig_mem
 
 end ChaseTree
 

--- a/ExistentialRules/ChaseSequence/Nontermination/RpcLike.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/RpcLike.lean
@@ -37,31 +37,33 @@ def RuleSet.neverTerminates (rs : RuleSet sig) (obs : ObsolescenceCondition sig)
 end BasicDefinitions
 
 /-- A `CyclicityDerivation` is an infinite list of `ChaseNode`s. We demand only that triggers are loaded, new terms keep being added (growing) and that triggers are unblockable. This is much different from a `ChaseDerivation` but intuitively, we can view a `CyclicityDerivation` as a very special non-continuous subderivation of a suitable `ChaseDerivation`. -/
-structure CyclicityDerivation (obs : ObsolescenceCondition sig) (rules : RuleSet sig)
+structure CyclicityDerivation (obs : ObsolescenceCondition sig) (rules : RuleSet sig) (hc : HeadChoice sig)
     extends RegularChaseDerivationSkeleton obs rules where
+  adheres_to_headChoice : ChaseDerivationSkeleton.adheres_to_headChoice toChaseDerivationSkeleton hc
   triggers_loaded : ∀ cd2, cd2 <:+ toChaseDerivationSkeleton -> ∀ next ∈ cd2.next, ∃ orig ∈ next.origin, orig.fst.val.loaded cd2.head.facts
   growing : ∀ cd2, cd2 <:+ toChaseDerivationSkeleton -> ∃ node ∈ cd2, ∃ t, ¬ t ∈ cd2.head.facts.terms ∧ t ∈ node.facts.terms
-  unblockable : ∀ node ∈ toChaseDerivationSkeleton, ∀ orig ∈ node.origin, (orig.fst.val.unblockable orig.snd.val orig.snd.isLt rules)
+  unblockable : ∀ node ∈ toChaseDerivationSkeleton, ∀ orig ∈ node.origin, (orig.fst.val.unblockable rules hc)
 
 namespace CyclicityDerivation
 
-variable {obs : ObsolescenceCondition sig} {rules : RuleSet sig}
+variable {obs : ObsolescenceCondition sig} {rules : RuleSet sig} {hc : HeadChoice sig}
 
-instance : Membership (RegularChaseNode obs rules) (CyclicityDerivation obs rules) where
+instance : Membership (RegularChaseNode obs rules) (CyclicityDerivation obs rules hc) where
   mem cd node := node ∈ cd.toChaseDerivationSkeleton
 
 /-- An element is a member of the derivation iff it occurs at some index in the underlying branch. -/
-theorem mem_iff {cd : CyclicityDerivation obs rules} : ∀ {e}, e ∈ cd ↔ ∃ n, cd.branch.get? n = some e := ChaseDerivationSkeleton.mem_iff
+theorem mem_iff {cd : CyclicityDerivation obs rules hc} : ∀ {e}, e ∈ cd ↔ ∃ n, cd.branch.get? n = some e := ChaseDerivationSkeleton.mem_iff
 
 /-- Each suffix of the underlying `ChaseDerivationSkeleton` is itself a `CyclicityDerivation`. -/
 def derivation_for_skeleton
-    (cd : CyclicityDerivation obs rules)
+    (cd : CyclicityDerivation obs rules hc)
     (l2 : RegularChaseDerivationSkeleton obs rules)
     (suffix : l2 <:+ cd.toChaseDerivationSkeleton) :
-    CyclicityDerivation obs rules where
+    CyclicityDerivation obs rules hc where
   branch := l2.branch
   isSome_head := l2.isSome_head
   triggers_exist := l2.triggers_exist
+  adheres_to_headChoice := by intro n n_mem; apply cd.adheres_to_headChoice; exact l2.mem_of_mem_suffix suffix _ n_mem
   triggers_loaded := by intro cd2 suffix2; apply cd.triggers_loaded; exact PossiblyInfiniteList.IsSuffix_trans suffix2 suffix
   growing := by intro cd2 suffix2; apply cd.growing; exact PossiblyInfiniteList.IsSuffix_trans suffix2 suffix
   unblockable := by
@@ -70,11 +72,11 @@ def derivation_for_skeleton
     exact ChaseDerivationSkeleton.mem_of_mem_suffix suffix _ node_mem
 
 /-- We state a simplified version of the `growing` property. -/
-theorem growing' {cd : CyclicityDerivation obs rules} : ∃ node ∈ cd, ∃ t, t ∉ cd.head.facts.terms ∧ t ∈ node.facts.terms :=
+theorem growing' {cd : CyclicityDerivation obs rules hc} : ∃ node ∈ cd, ∃ t, t ∉ cd.head.facts.terms ∧ t ∈ node.facts.terms :=
   cd.growing _ (cd.branch.IsSuffix_refl)
 
 /-- Given a list of terms, we can find a suffix that contains a term that is not part of this list because of the growing property. This result is closest to the `growing'` statement. -/
-theorem growing'_for_list (cd : CyclicityDerivation obs rules) (l : List (GroundTerm sig)) :
+theorem growing'_for_list (cd : CyclicityDerivation obs rules hc) (l : List (GroundTerm sig)) :
     ∃ node ∈ cd, ∃ t, t ∉ cd.head.facts.terms ∧ t ∈ node.facts.terms ∧ t ∉ l := by
   induction l generalizing cd with
   | nil => rcases cd.growing' with ⟨node, node_mem, t, t_not_mem, t_mem⟩; exact ⟨node, node_mem, t, t_not_mem, t_mem, by simp⟩
@@ -95,7 +97,7 @@ theorem growing'_for_list (cd : CyclicityDerivation obs rules) (l : List (Ground
         | inl contra => apply s_not_mem; rw [contra, eq]; simp only [derivation_for_skeleton, head_eq]; exact t_mem
 
 /-- We restate the `growing` property using predecessor vocabulary available for `ChaseDerivationSkeleton`s. -/
-theorem growing'' {cd : CyclicityDerivation obs rules} : ∀ node : cd.Node,
+theorem growing'' {cd : CyclicityDerivation obs rules hc} : ∀ node : cd.Node,
     ∃ node2 : cd.Node, node ≺ node2 ∧ ∃ t, ¬ t ∈ node.val.facts.terms ∧ t ∈ node2.val.facts.terms := by
   intro ⟨node, node_mem⟩
   rw [ChaseDerivationSkeleton.mem_iff] at node_mem
@@ -121,7 +123,7 @@ theorem growing'' {cd : CyclicityDerivation obs rules} : ∀ node : cd.Node,
   . exists t; simp only [node_head, t_not_mem, node2_cd2, not_false_iff, true_and]; exact t_mem
 
 /-- Since the derivation is growing, a next node always exists. -/
-theorem isSome_next {cd : CyclicityDerivation obs rules} : cd.toChaseDerivationSkeleton.next.isSome := by
+theorem isSome_next {cd : CyclicityDerivation obs rules hc} : cd.toChaseDerivationSkeleton.next.isSome := by
   rcases growing'' ⟨cd.head, cd.head_mem⟩ with ⟨n2, prec, _⟩
   have n2_mem := n2.property
   rw [ChaseDerivationSkeleton.mem_iff_eq_head_or_mem_tail] at n2_mem
@@ -130,26 +132,26 @@ theorem isSome_next {cd : CyclicityDerivation obs rules} : cd.toChaseDerivationS
   | inr n2_mem => rcases n2_mem with ⟨n2_mem, _⟩; exact n2_mem
 
 /-- Lifting `ChaseDerivationSkeleton.next` to the `CyclicityDerivation`. -/
-def next (cd : CyclicityDerivation obs rules) : RegularChaseNode obs rules := cd.toChaseDerivationSkeleton.next.get (isSome_next)
+def next (cd : CyclicityDerivation obs rules hc) : RegularChaseNode obs rules := cd.toChaseDerivationSkeleton.next.get (isSome_next)
 
 /-- The `next` node is a member. -/
 @[grind <-]
-theorem next_mem {cd : CyclicityDerivation obs rules} : cd.next ∈ cd := by
+theorem next_mem {cd : CyclicityDerivation obs rules hc} : cd.next ∈ cd := by
   apply ChaseDerivationSkeleton.next_mem_of_mem; simp [next]
 
 /-- The origin of the `next` `ChaseNode` needs to be set. -/
 @[grind <-]
-theorem isSome_origin_next {cd : CyclicityDerivation obs rules} : cd.next.origin.isSome := by
+theorem isSome_origin_next {cd : CyclicityDerivation obs rules hc} : cd.next.origin.isSome := by
   apply cd.toChaseDerivationSkeleton.isSome_origin_next; simp [next]
 
 /-- The fact set of the `next` `ChaseNode` consists exactly of the facts from `head` and the result of the trigger that introduces `next`. -/
-theorem facts_next {cd : CyclicityDerivation obs rules} :
+theorem facts_next {cd : CyclicityDerivation obs rules hc} :
     cd.next.facts = cd.head.facts ∪ (ChaseNode.origin_result cd.next cd.isSome_origin_next).toSet := by
   apply cd.toChaseDerivationSkeleton.facts_next; simp [next]
 
 /-- The trigger used to derive `ChaseDerivationSkeleton.next` is loaded for `ChaseDerivationSkeleton.head`. -/
 @[grind <-]
-theorem loaded_trigger_origin_next {cd : CyclicityDerivation obs rules} :
+theorem loaded_trigger_origin_next {cd : CyclicityDerivation obs rules hc} :
     (cd.next.origin.get cd.isSome_origin_next).fst.val.loaded cd.head.facts := by
   have trg_loaded := cd.triggers_loaded _ (cd.branch.IsSuffix_refl) cd.next (by simp [next, ChaseDerivationSkeleton.next])
   rcases trg_loaded with ⟨orig, orig_mem, trg_loaded⟩
@@ -158,18 +160,18 @@ theorem loaded_trigger_origin_next {cd : CyclicityDerivation obs rules} :
   exact trg_loaded
 
 /-- The tail of a `CyclicityDerivation` is again a `CyclicityDerivation`. -/
-def tail (cd : CyclicityDerivation obs rules) : CyclicityDerivation obs rules :=
+def tail (cd : CyclicityDerivation obs rules hc) : CyclicityDerivation obs rules hc :=
   cd.derivation_for_skeleton (ChaseDerivationSkeleton.tail cd.toChaseDerivationSkeleton isSome_next) (cd.branch.IsSuffix_tail)
 
 /-- The `ChaseDerivationSkeleton.head` of the `tail` is `ChaseDerivationSkeleton.next`. -/
 @[simp, grind =]
-theorem head_tail {cd : CyclicityDerivation obs rules} : cd.tail.head = cd.next := ChaseDerivationSkeleton.head_tail'
+theorem head_tail {cd : CyclicityDerivation obs rules hc} : cd.tail.head = cd.next := ChaseDerivationSkeleton.head_tail'
 
 /-- We define a shortcut for `RegularChaseDerivationSkeleton.result`. -/
-abbrev result (cd : CyclicityDerivation obs rules) := RegularChaseDerivationSkeleton.result cd.toChaseDerivationSkeleton
+abbrev result (cd : CyclicityDerivation obs rules hc) := RegularChaseDerivationSkeleton.result cd.toChaseDerivationSkeleton
 
 /-- The result of a `CyclicityDerivation` is infinite due to the `growing` property. -/
-theorem result_infinite {cd : CyclicityDerivation obs rules} : ¬ cd.result.finite := by
+theorem result_infinite {cd : CyclicityDerivation obs rules hc} : ¬ cd.result.finite := by
   intro ⟨l, _, eq⟩
   have sub_res : l.toSet ⊆ cd.result := by intro e e_mem; rw [← eq, ← List.mem_toSet]; exact e_mem
   have res_sub : cd.result ⊆ l.toSet := by intro e e_mem; rw [List.mem_toSet, eq]; exact e_mem
@@ -182,7 +184,7 @@ theorem result_infinite {cd : CyclicityDerivation obs rules} : ¬ cd.result.fini
   exact t_mem
 
 /-- Each `CyclicityDerivation` is infinite because it is `growing`. It might surprise that this is independant from the above result. However, note that we can only relate finiteness of the result and termination for proper ChaseBranches so corresponding results are not applicable here. -/
-theorem infinite {cd : CyclicityDerivation obs rules} : ¬ cd.terminates := by
+theorem infinite {cd : CyclicityDerivation obs rules hc} : ¬ cd.terminates := by
   intro contra
   let node : cd.Node := ⟨cd.last contra, cd.last_mem contra⟩
   rcases cd.growing'' node with ⟨node2, prec, ⟨t, t_not_mem, t_mem⟩⟩
@@ -190,187 +192,68 @@ theorem infinite {cd : CyclicityDerivation obs rules} : ¬ cd.terminates := by
   apply FactSet.terms_subset_of_subset (RegularChaseDerivationSkeleton.facts_node_subset_of_prec (cd.each_prec_last contra node2))
   exact t_mem
 
-/-- In every `TreeDerivation` that starts on the same initial fact set as the `CyclicityDerivation`, there exists a branch that corresponds to the `CyclicityDerivation`, meaning that it has the same result. -/
-theorem corresponding_tree_branch_exists {cd : CyclicityDerivation obs rules}
+/-- For each node in the `CyclicityDerivation`, there is a node in the `subderivation_for_headChoice` for every `TreeDerivation` subsumes the facts. -/
+theorem mem_subderivation_for_headChoice_of_mem {cd : CyclicityDerivation obs rules hc}
     (td : RegularTreeDerivation obs rules) (same_start : cd.head.facts = td.root.facts) :
-    ∃ deriv ∈ td.branches, cd.result ⊆ RegularChaseDerivation.result deriv := by
-  -- NOTE: The need for the suffix part of the property might not be obvious. This is required to show `different_value_exists` down below. For this we need to ensure that every possible value for β is already restricted to adhering to the suffix property. The more general claim without this property would not hold.
-  let β := { pair : CyclicityDerivation obs rules × td.NodeWithAddress // pair.fst.head.facts ⊆ pair.snd.node.facts ∧ pair.fst.toChaseDerivationSkeleton <:+ cd.toChaseDerivationSkeleton}
-  let mapper : β -> td.NodeWithAddress := Prod.snd ∘ Subtype.val
-  let start : β := ⟨(cd, TreeDerivation.NodeWithAddress.root td), by
-    constructor
-    . rw [same_start]; simp only [TreeDerivation.NodeWithAddress.root]; exact Set.subset_refl
-    . exact PossiblyInfiniteList.IsSuffix_refl⟩
-  let generator : β -> β := fun b =>
-    let next := b.val.fst.next
-    let origin := next.origin.get b.val.fst.isSome_origin_next
-    have unblk := b.val.fst.unblockable next b.val.fst.next_mem origin (by simp [origin]) td b.val.snd (by
-      have loaded : origin.fst.val.loaded b.val.fst.head.facts := b.val.fst.loaded_trigger_origin_next
-      apply Set.subset_trans loaded
-      exact b.property.left)
-    let new_snd := Classical.choose unblk
-    have new_snd_spec := Classical.choose_spec unblk
-    ⟨(b.val.fst.tail, new_snd), by
-      constructor
-      . simp only
-        rw [head_tail, b.val.fst.facts_next]
-        rw [Set.union_subset_iff_both_subset]; constructor
-        . apply Set.subset_trans b.property.left
-          exact td.facts_node_subset_of_prec new_snd_spec.left
-        . exact new_snd_spec.right
-      . exact PossiblyInfiniteList.IsSuffix_trans PossiblyInfiniteList.IsSuffix_tail b.property.right⟩
-  have firstComponent_branch_eq : ∀ b, ∀ i, b.val.fst.branch.drop i = ((InfiniteList.iterate b generator).get i).val.fst.branch := by
-      intro b i
-      induction i with
-      | zero => rw [← InfiniteList.head_eq, InfiniteList.head_iterate]; simp
-      | succ i ih =>
-        rw [InfiniteList.get_iterate] at ih
-        rw [InfiniteList.get_succ_iterate]
-        conv => right; right; right; right; right; fun; unfold generator
-        simp only [tail, ChaseDerivationSkeleton.tail, derivation_for_skeleton, ChaseDerivationSkeleton.derivation_for_branch_suffix]
-        rw [← ih]
-        simp
-  have different_value_exists : ∀ b, ∃ n, mapper (generator.repeat_fun n b) ≠ mapper b := by
-    intro b
-    suffices ∀ l : List (GroundTerm sig), ∃ n, ∃ t,
-        t ∈ (td.generatedFacts (generator.repeat_fun n b).val.fst.head).terms ∧ t ∉ l by
-      rcases FactSet.terms_finite_of_finite _ (td.generatedFacts_finite_of_mem (mapper b).mem) with ⟨ts, _, ts_eq⟩
-      rcases this ts with ⟨n, t, t_mem, t_nmem⟩
-      exists n
-      intro contra
-      apply t_nmem
-      rw [ts_eq, ← contra]
-      rcases t_mem with ⟨f, f_mem, t_mem⟩
-      exists f; simp only [t_mem, and_true]
-      constructor
-      . exact (generator.repeat_fun n b).property.left _ f_mem.left
-      . exact f_mem.right
-    intro l
-    rcases b.val.fst.growing'_for_list l with ⟨node, node_mem, t, t_not_mem, t_mem, t_not_mem_l⟩
-    rw [mem_iff] at node_mem; rcases node_mem with ⟨n, node_mem⟩
-    exists n, t; simp only [t_not_mem_l, not_false_iff, and_true]
-    rw [← PossiblyInfiniteList.head_drop, firstComponent_branch_eq, InfiniteList.get_iterate] at node_mem
-    simp only [ChaseDerivationSkeleton.head]
-    rcases t_mem with ⟨f, f_mem, t_mem⟩
-    exists f; simp only [t_mem, and_true]; constructor; simp only [node_mem, Option.get_some]; exact f_mem
-    rw [td.root.outgoingFacts_eq, ← same_start]
-    intro contra; apply t_not_mem
-    exists f; simp only [t_mem, and_true]
-    apply RegularChaseDerivationSkeleton.facts_node_subset_every_mem _ _ _ contra
-    apply ChaseDerivationSkeleton.mem_of_mem_suffix b.property.right; exact b.val.fst.head_mem
-  let condensed_generator := Function.condense_generator generator mapper different_value_exists
-  let deriv := td.generate_subderivation_from_sparse_of_total_generator start condensed_generator mapper (by
-    suffices ∀ b n, mapper b ≼ mapper (generator.repeat_fun n b) by
-      intro b; constructor
-      . rcases Function.condense_generator_eq_repeat_generator generator mapper different_value_exists b with ⟨n, eq⟩
-        unfold condensed_generator; rw [eq]; exact this b n
-      . apply Ne.symm; apply Function.condense_generator_next_ne
+    ∀ node ∈ cd, ∃ node' ∈ td.subderivation_for_headChoice hc, node.facts ⊆ node'.facts := by
+  intro node node_mem; let node : cd.Node := ⟨node, node_mem⟩; show ∃ node' ∈ td.subderivation_for_headChoice hc, node.val.facts ⊆ node'.facts
+  induction node using cd.mem_rec with
+  | head =>
+    exists (td.subderivation_for_headChoice hc).head; constructor; exact ChaseDerivationSkeleton.head_mem
+    rw [td.head_subderivation_for_headChoice, same_start]; exact Set.subset_refl
+  | step cd2 suf ih next next_mem =>
+    rcases ih with ⟨node', node'_mem, sub⟩
+    let cd2' : CyclicityDerivation obs rules hc := cd.derivation_for_skeleton cd2 suf
+    have next_eq : next = cd2'.next := by simp only [CyclicityDerivation.next, cd2', derivation_for_skeleton]; rw [Option.mem_def] at next_mem; simp [next_mem]
+    let orig := next.origin.get (cd2.isSome_origin_next next_mem)
+    rcases cd2'.unblockable next (cd2'.next_mem_of_mem _ next_mem) orig (by simp [orig]) td ⟨node', node'_mem⟩ (by apply Set.subset_trans _ sub; simp only [orig, next_eq]; exact cd2'.loaded_trigger_origin_next) with ⟨node2, node2_succ, next_result_sub⟩
+    exists node2.val; constructor; exact node2.property
+    have := cd2.facts_next next_mem
+    rw [← next.ingoingFacts_eq, cd2.facts_next next_mem]
+    rw [Set.union_subset_iff_both_subset]; constructor
+    . rw [cd2.head.outgoingFacts_eq]; apply Set.subset_trans sub
+      exact RegularChaseDerivationSkeleton.facts_node_subset_of_prec node2_succ
+    . have index_eq : (hc orig.fst.val).val = orig.snd.val := by
+        rw [cd2'.adheres_to_headChoice _ (cd2'.next_mem_of_mem _ next_mem) orig (by simp [orig, ChaseNode.origin])]
+      rw [ChaseNode.origin_result_eq (cd2.isSome_origin_next next_mem) (trg := orig.fst.val) rfl index_eq]
+      exact next_result_sub
 
-    intro b n
-    induction n with
-    | zero => rw [Function.repeat_zero]; grind
-    | succ n ih =>
-      rw [Function.repeat_succ]
-      apply TreeDerivation.predecessor_trans ih
-      let next := (generator.repeat_fun n b).val.fst.next
-      let origin := next.origin.get (generator.repeat_fun n b).val.fst.isSome_origin_next
-      have unblk := (generator.repeat_fun n b).val.fst.unblockable next (generator.repeat_fun n b).val.fst.next_mem origin (by simp [origin]) td (generator.repeat_fun n b).val.snd (by
-        have loaded : origin.fst.val.loaded (generator.repeat_fun n b).val.fst.head.facts := (generator.repeat_fun n b).val.fst.loaded_trigger_origin_next
-        apply Set.subset_trans loaded
-        exact (generator.repeat_fun n b).property.left)
-      exact (Classical.choose_spec unblk).left)
-
-  exists deriv; constructor
-  . apply td.generate_subderivation_from_sparse_of_total_generator_mem_branches
-    simp [mapper, start]
-  . suffices ∀ node : cd.Node, ∃ (node2 : cd.Node), node ≼ node2 ∧ node2.val ∈ (InfiniteList.iterate start condensed_generator).map (fun e => e.val.fst.head) by
-      intro f ⟨node, node_mem, f_mem⟩
-      rcases this ⟨node, node_mem⟩ with ⟨node2, prec, node2_mem⟩
-      rw [InfiniteList.mem_map] at node2_mem
-      rcases node2_mem with ⟨b, b_mem, node2_mem⟩
-      exists b.val.snd.node; constructor
-      . rw [← deriv.mem_def]
-        apply td.mem_generate_subderivation_from_sparse_of_total_generator_of_mem_original_generator
-        exact b_mem
-      . apply b.property.left
-        rw [node2_mem]
-        apply RegularChaseDerivationSkeleton.facts_node_subset_of_prec prec
-        exact f_mem
-    suffices ∀ i, ∃ j, (condensed_generator.repeat_fun j start).val.fst.branch <:+ cd.branch.drop i by
-      intro ⟨node, node_mem⟩
-      rcases ChaseDerivationSkeleton.mem_iff.mp node_mem with ⟨i, node_mem⟩
-      rcases this i with ⟨j, suffix⟩
-      exists ⟨(condensed_generator.repeat_fun j start).val.fst.head, by apply ChaseDerivationSkeleton.mem_of_mem_suffix (PossiblyInfiniteList.IsSuffix_trans suffix (PossiblyInfiniteList.IsSuffix_drop _)); exact ChaseDerivationSkeleton.head_mem⟩
-      constructor
-      . exists cd.derivation_for_branch_suffix (cd.branch.drop i) (PossiblyInfiniteList.IsSuffix_drop _) (by grind)
-        constructor; exact PossiblyInfiniteList.IsSuffix_drop _
-        constructor; simp only [ChaseDerivationSkeleton.derivation_for_branch_suffix, ChaseDerivationSkeleton.head]; grind
-        simp only [ChaseDerivationSkeleton.derivation_for_branch_suffix]
-        apply PossiblyInfiniteList.mem_of_mem_suffix suffix
-        exact ChaseDerivationSkeleton.head_mem
-      . rw [InfiniteList.mem_map]
-        exists condensed_generator.repeat_fun j start; constructor
-        . rw [InfiniteList.mem_iff]
-          exists j
-          rw [InfiniteList.get_iterate]
-        . rfl
-    suffices ∀ i, ∃ j, (condensed_generator.repeat_fun j start).val.fst.toChaseDerivationSkeleton <:+ (generator.repeat_fun i start).val.fst.toChaseDerivationSkeleton by intro i; rw [firstComponent_branch_eq start i]; simp only [InfiniteList.get_iterate]; exact this i
-    suffices ∀ b i, (generator.repeat_fun i b).val.fst.toChaseDerivationSkeleton <:+ b.val.fst.toChaseDerivationSkeleton by
-      suffices condensed_exceeds_generator : ∀ b i, ∃ j k, (condensed_generator.repeat_fun j b) = (generator.repeat_fun (i+k) b) by
-        intro i; rcases condensed_exceeds_generator start i with ⟨j, k, eq⟩
-        exists j; rw [eq, Function.repeat_add, Function.repeat_swap]
-        apply this
-      intro b i
-      induction i with
-      | zero => exists 0, 0
-      | succ i ih =>
-        rcases ih with ⟨j, k, ih⟩
-        rcases Function.condense_generator_eq_repeat_generator generator mapper different_value_exists (condensed_generator.repeat_fun j b) with ⟨k', eq⟩
-        exists j.succ, k + k' - 1
-        rw [Nat.add_assoc, Nat.add_comm 1 _, Nat.sub_one_add_one (by
-          suffices k' ≠ 0 by grind
-          intro contra
-          rw [contra, Function.repeat_zero] at eq
-          apply Function.condense_generator_next_ne (generator := generator) (mapper := mapper)
-          rw [eq]
-        )]
-        rw [Function.repeat_succ]
-        unfold condensed_generator
-        rw [eq, ih]
-        conv => right; rw [← Nat.add_assoc, Function.repeat_add, Function.repeat_swap]
-    intro b i
-    induction i with
-    | zero =>  simp only [Function.repeat_zero]; exact PossiblyInfiniteList.IsSuffix_refl
-    | succ i ih => rw [Function.repeat_succ]; exact PossiblyInfiniteList.IsSuffix_trans PossiblyInfiniteList.IsSuffix_tail ih
+/-- The result of a `CyclicityDerivation` is a subset of the result of the `subderivation_for_headChoice` for every `TreeDerivation`. -/
+theorem result_subset_result_subderivation_for_headChoice {cd : CyclicityDerivation obs rules hc}
+    (td : RegularTreeDerivation obs rules) (same_start : cd.head.facts = td.root.facts) :
+    cd.result ⊆ RegularChaseDerivation.result (td.subderivation_for_headChoice hc) := by
+  intro f ⟨node, node_mem, f_mem⟩
+  rcases cd.mem_subderivation_for_headChoice_of_mem td same_start node node_mem with ⟨node', node'_mem, sub⟩
+  exists node'; constructor; exact node'_mem; apply sub; exact f_mem
 
 end CyclicityDerivation
 
 
 /-- This is the CyclicitySequence from the RPC paper. For us, it is a `CyclicityDerivation` that starts on a database.  -/
-structure CyclicityBranch (obs : ObsolescenceCondition sig) (kb : KnowledgeBase sig) extends CyclicityDerivation obs kb.rules where
+structure CyclicityBranch (obs : ObsolescenceCondition sig) (kb : KnowledgeBase sig) (hc : HeadChoice sig) extends CyclicityDerivation obs kb.rules hc where
   database_first :
     toChaseDerivationSkeleton.head.facts = kb.db.toFactSet ∧
     toChaseDerivationSkeleton.head.origin = none
 
 namespace CyclicityBranch
 
-variable {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig}
+variable {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig} {hc : HeadChoice sig}
 
-/-- In every `ChaseTree`, there exists a branch that corresponds to the `CyclicityBranch`, meaning that it has the same result. -/
-theorem corresponding_tree_branch_exists {cb : CyclicityBranch obs kb} (ct : RegularChaseTree obs kb) :
-    ∃ branch : RegularChaseBranch obs kb, branch.toChaseDerivation ∈ ct.branches ∧ cb.result ⊆ branch.result := by
-  rcases cb.toCyclicityDerivation.corresponding_tree_branch_exists ct.toTreeDerivation (by rw [cb.database_first.left, ← RegularChaseNode.outgoingFacts_eq, ct.database_first.right.left]) with ⟨cd, cd_mem, res_sub⟩
-  exists ct.chaseBranch_for_branch cd_mem
+/-- The result of a `CyclicityBranch` is a subset of the result of the `subderivation_for_headChoice` for every `ChaseTree`. -/
+theorem result_subset_result_subderivation_for_headChoice {cb : CyclicityBranch obs kb hc} (ct : RegularChaseTree obs kb) :
+    cb.result ⊆ RegularChaseBranch.result (ct.subderivation_for_headChoice hc) := by
+  apply CyclicityDerivation.result_subset_result_subderivation_for_headChoice
+  rw [cb.database_first.left, ← RegularChaseNode.outgoingFacts_eq, ct.database_first.right.left]
 
 /-- If a KB admist a `CyclicityBranch`, then its rule set `neverTerminates`. -/
 theorem neverTerminates_of_cyclicityBranch {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig}
-    (cb : CyclicityBranch obs kb) : kb.rules.neverTerminates obs (RegularChaseNode obs kb.rules) := by
+    (cb : CyclicityBranch obs kb hc) : kb.rules.neverTerminates obs (RegularChaseNode obs kb.rules) := by
   exists kb.db
   intro ct terminates
-  rcases cb.corresponding_tree_branch_exists ct with ⟨branch, branch_mem, res_sub⟩
-  specialize terminates _ branch_mem
+  let branch : RegularChaseBranch obs kb := ct.subderivation_for_headChoice hc
+  specialize terminates branch.toChaseDerivation (ct.subderivation_for_headChoice_mem_branches)
   apply cb.result_infinite
-  apply Set.finite_of_subset_finite _ res_sub
+  apply Set.finite_of_subset_finite _ (cb.result_subset_result_subderivation_for_headChoice ct)
   rw [← branch.terminates_iff_result_finite]
   exact terminates
 

--- a/ExistentialRules/ChaseSequence/Nontermination/RpcLike.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/RpcLike.lean
@@ -8,6 +8,7 @@ module
 public import ExistentialRules.ChaseSequence.Termination.Basic
 import ExistentialRules.ChaseSequence.Nontermination.CondenseGenerator
 import ExistentialRules.ChaseSequence.Nontermination.SparseSubderivationGenerator
+public import ExistentialRules.ChaseSequence.Nontermination.Unblockability
 
 /-!
 # RPC-like Non-Termination
@@ -34,18 +35,6 @@ def RuleSet.neverTerminates (rs : RuleSet sig) (obs : ObsolescenceCondition sig)
   ∃ (db : Database sig), { rules := rs, db := db : KnowledgeBase sig }.neverTerminates obs N
 
 end BasicDefinitions
-
-
-/-- A trigger is unblockable if its result necessarily occurs in every derivation where the trigger is loaded. In the introducing paper this is called g-unblockable. -/
-def Trigger.unblockable
-    {obs : ObsolescenceCondition sig}
-    (trg : Trigger obs.toLaxObsolescenceCondition)
-    (i : Nat)
-    (lt : i < trg.rule.head.length)
-    (rules : RuleSet sig) : Prop :=
-  ∀ td : RegularTreeDerivation obs rules, ∀ node : td.NodeWithAddress, trg.loaded node.node.facts ->
-  ∃ node2 : td.NodeWithAddress, node ≼ node2 ∧
-  (trg.mapped_head[i]'(by grind)).toSet ⊆ node2.node.facts
 
 /-- A `CyclicityDerivation` is an infinite list of `ChaseNode`s. We demand only that triggers are loaded, new terms keep being added (growing) and that triggers are unblockable. This is much different from a `ChaseDerivation` but intuitively, we can view a `CyclicityDerivation` as a very special non-continuous subderivation of a suitable `ChaseDerivation`. -/
 structure CyclicityDerivation (obs : ObsolescenceCondition sig) (rules : RuleSet sig)

--- a/ExistentialRules/ChaseSequence/Nontermination/RpcLike.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/RpcLike.lean
@@ -213,9 +213,7 @@ theorem mem_subderivation_for_headChoice_of_mem {cd : CyclicityDerivation obs ru
     rw [Set.union_subset_iff_both_subset]; constructor
     . rw [cd2.head.outgoingFacts_eq]; apply Set.subset_trans sub
       exact RegularChaseDerivationSkeleton.facts_node_subset_of_prec node2_succ
-    . have index_eq : (hc orig.fst.val).val = orig.snd.val := by
-        rw [cd2'.adheres_to_headChoice _ (cd2'.next_mem_of_mem _ next_mem) orig (by simp [orig, ChaseNode.origin])]
-      rw [ChaseNode.origin_result_eq (cd2.isSome_origin_next next_mem) (trg := orig.fst.val) rfl index_eq]
+    . rw [ChaseNode.origin_result_eq_of_adheres_to_headChoice _ (cd2'.adheres_to_headChoice _ (cd2'.next_mem_of_mem _ next_mem))]
       exact next_result_sub
 
 /-- The result of a `CyclicityDerivation` is a subset of the result of the `subderivation_for_headChoice` for every `TreeDerivation`. -/

--- a/ExistentialRules/ChaseSequence/Nontermination/RpcLike.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/RpcLike.lean
@@ -194,19 +194,22 @@ theorem infinite {cd : CyclicityDerivation obs rules hc} : ¬ cd.terminates := b
 
 /-- For each node in the `CyclicityDerivation`, there is a node in the `subderivation_for_headChoice` for every `TreeDerivation` subsumes the facts. -/
 theorem mem_subderivation_for_headChoice_of_mem {cd : CyclicityDerivation obs rules hc}
-    (td : RegularTreeDerivation obs rules) (same_start : cd.head.facts = td.root.facts) :
-    ∀ node ∈ cd, ∃ node' ∈ td.subderivation_for_headChoice hc, node.facts ⊆ node'.facts := by
-  intro node node_mem; let node : cd.Node := ⟨node, node_mem⟩; show ∃ node' ∈ td.subderivation_for_headChoice hc, node.val.facts ⊆ node'.facts
+    (kb : KnowledgeBase sig) (rules_eq : kb.rules = rules)
+    (ct : RegularChaseTree obs kb) (same_start : cd.head.facts = ct.root.facts) :
+    ∀ node ∈ cd, ∃ node' ∈ (ct.subderivation_for_headChoice hc).toChaseDerivation, node.facts ⊆ node'.facts := by
+  intro node node_mem; let node : cd.Node := ⟨node, node_mem⟩
+  show ∃ node' ∈ (ct.subderivation_for_headChoice hc).toChaseDerivation, node.val.facts ⊆ node'.facts
   induction node using cd.mem_rec with
   | head =>
-    exists (td.subderivation_for_headChoice hc).head; constructor; exact ChaseDerivationSkeleton.head_mem
-    rw [td.head_subderivation_for_headChoice, same_start]; exact Set.subset_refl
+    exists (ct.subderivation_for_headChoice hc).head; constructor; exact ChaseDerivationSkeleton.head_mem
+    simp only [ChaseTree.subderivation_for_headChoice]
+    rw [TreeDerivation.head_subderivation_for_headChoice, same_start]; exact Set.subset_refl
   | step cd2 suf ih next next_mem =>
     rcases ih with ⟨node', node'_mem, sub⟩
     let cd2' : CyclicityDerivation obs rules hc := cd.derivation_for_skeleton cd2 suf
     have next_eq : next = cd2'.next := by simp only [CyclicityDerivation.next, cd2', derivation_for_skeleton]; rw [Option.mem_def] at next_mem; simp [next_mem]
     let orig := next.origin.get (cd2.isSome_origin_next next_mem)
-    rcases cd2'.unblockable next (cd2'.next_mem_of_mem _ next_mem) orig (by simp [orig]) td ⟨node', node'_mem⟩ (by apply Set.subset_trans _ sub; simp only [orig, next_eq]; exact cd2'.loaded_trigger_origin_next) with ⟨node2, node2_succ, next_result_sub⟩
+    rcases cd2'.unblockable next (cd2'.next_mem_of_mem _ next_mem) orig (by simp [orig]) kb rules_eq ct ⟨node', node'_mem⟩ (by apply Set.subset_trans _ sub; simp only [orig, next_eq]; exact cd2'.loaded_trigger_origin_next) with ⟨node2, node2_succ, next_result_sub⟩
     exists node2.val; constructor; exact node2.property
     have := cd2.facts_next next_mem
     rw [← next.ingoingFacts_eq, cd2.facts_next next_mem]
@@ -218,10 +221,11 @@ theorem mem_subderivation_for_headChoice_of_mem {cd : CyclicityDerivation obs ru
 
 /-- The result of a `CyclicityDerivation` is a subset of the result of the `subderivation_for_headChoice` for every `TreeDerivation`. -/
 theorem result_subset_result_subderivation_for_headChoice {cd : CyclicityDerivation obs rules hc}
-    (td : RegularTreeDerivation obs rules) (same_start : cd.head.facts = td.root.facts) :
-    cd.result ⊆ RegularChaseDerivation.result (td.subderivation_for_headChoice hc) := by
+    (kb : KnowledgeBase sig) (rules_eq : kb.rules = rules)
+    (ct : RegularChaseTree obs kb) (same_start : cd.head.facts = ct.root.facts) :
+    cd.result ⊆ RegularChaseBranch.result (ct.subderivation_for_headChoice hc) := by
   intro f ⟨node, node_mem, f_mem⟩
-  rcases cd.mem_subderivation_for_headChoice_of_mem td same_start node node_mem with ⟨node', node'_mem, sub⟩
+  rcases cd.mem_subderivation_for_headChoice_of_mem kb rules_eq ct same_start node node_mem with ⟨node', node'_mem, sub⟩
   exists node'; constructor; exact node'_mem; apply sub; exact f_mem
 
 end CyclicityDerivation
@@ -240,7 +244,7 @@ variable {obs : ObsolescenceCondition sig} {kb : KnowledgeBase sig} {hc : HeadCh
 /-- The result of a `CyclicityBranch` is a subset of the result of the `subderivation_for_headChoice` for every `ChaseTree`. -/
 theorem result_subset_result_subderivation_for_headChoice {cb : CyclicityBranch obs kb hc} (ct : RegularChaseTree obs kb) :
     cb.result ⊆ RegularChaseBranch.result (ct.subderivation_for_headChoice hc) := by
-  apply CyclicityDerivation.result_subset_result_subderivation_for_headChoice
+  apply CyclicityDerivation.result_subset_result_subderivation_for_headChoice _ rfl
   rw [cb.database_first.left, ← RegularChaseNode.outgoingFacts_eq, ct.database_first.right.left]
 
 /-- If a KB admist a `CyclicityBranch`, then its rule set `neverTerminates`. -/

--- a/ExistentialRules/ChaseSequence/Nontermination/SparseSubderivationGenerator.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/SparseSubderivationGenerator.lean
@@ -18,6 +18,9 @@ Instead, we get a generator that will always yield a node that occurs somewhere 
 We can then "fill in the gaps" to get the full branch. We do this by adjusting the generator function to fill in the blanks for us.
 This is a bit technical but hopefully abstracted away enough so that the internals are irrelevant outside of this file.
 
+LOOKS LIKE WITH HEAD CHOICES INVOLVED, WE ACTUALLY DO NOT NEED THIS ANYMORE.
+MAYBE THIS IS STILL USEFUL AS GENERAL MACHINERY BUT THEN IT SHOULD MOVED TO SOME OTHER PLACE EVENTUALLY.
+
 -/
 
 namespace TreeDerivation

--- a/ExistentialRules/ChaseSequence/Nontermination/Unblockability.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/Unblockability.lean
@@ -1,0 +1,33 @@
+/-
+Copyright 2026 Lukas Gerlach
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+module
+
+public import ExistentialRules.ChaseSequence.TreeDerivation
+
+/-!
+# Unblockability
+
+Here we define what it means for a trigger to be unblockable and we also introduce overapproximations that can be used to witness unblockability.
+
+THIS IS VERY MUCH WORK IN PROGRESS!
+-/
+
+public section
+
+variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
+
+/-- A trigger is unblockable if its result necessarily occurs in every derivation where the trigger is loaded. In the introducing paper this is called g-unblockable. -/
+@[expose]
+def Trigger.unblockable
+    {obs : ObsolescenceCondition sig}
+    (trg : Trigger obs.toLaxObsolescenceCondition)
+    (i : Nat)
+    (lt : i < trg.rule.head.length)
+    (rules : RuleSet sig) : Prop :=
+  ∀ td : RegularTreeDerivation obs rules, ∀ node : td.NodeWithAddress, trg.loaded node.node.facts ->
+  ∃ node2 : td.NodeWithAddress, node ≼ node2 ∧
+  (trg.mapped_head[i]'(by grind)).toSet ⊆ node2.node.facts
+

--- a/ExistentialRules/ChaseSequence/Nontermination/Unblockability.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/Unblockability.lean
@@ -28,5 +28,5 @@ def Trigger.unblockable
     (hc : HeadChoice sig) : Prop :=
   ∀ td : RegularTreeDerivation obs rules, ∀ node : (td.subderivation_for_headChoice hc).Node, trg.loaded node.val.facts ->
   ∃ node2 : (td.subderivation_for_headChoice hc).Node, node ≼ node2 ∧
-  (trg.mapped_head[(hc trg).val]'(by grind)).toSet ⊆ node2.val.facts
+  (trg.output_for_headChoice hc).toSet ⊆ node2.val.facts
 

--- a/ExistentialRules/ChaseSequence/Nontermination/Unblockability.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/Unblockability.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 module
 
-public import ExistentialRules.ChaseSequence.TreeDerivation
+public import ExistentialRules.ChaseSequence.Nontermination.HeadChoice
 
 /-!
 # Unblockability
@@ -19,15 +19,14 @@ public section
 
 variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
 
-/-- A trigger is unblockable if its result necessarily occurs in every derivation where the trigger is loaded. In the introducing paper this is called g-unblockable. -/
+/-- A trigger is unblockable for a given `HeadChoice` if, for every derivation, when the trigger is loaded in a node of the branch indicated by the `HeacChoice`, then the `HeadChoice` result of the trigger also occurs in that branch. In the introducing paper this is called g-unblockable. -/
 @[expose]
 def Trigger.unblockable
     {obs : ObsolescenceCondition sig}
     (trg : Trigger obs.toLaxObsolescenceCondition)
-    (i : Nat)
-    (lt : i < trg.rule.head.length)
-    (rules : RuleSet sig) : Prop :=
-  ∀ td : RegularTreeDerivation obs rules, ∀ node : td.NodeWithAddress, trg.loaded node.node.facts ->
-  ∃ node2 : td.NodeWithAddress, node ≼ node2 ∧
-  (trg.mapped_head[i]'(by grind)).toSet ⊆ node2.node.facts
+    (rules : RuleSet sig)
+    (hc : HeadChoice sig) : Prop :=
+  ∀ td : RegularTreeDerivation obs rules, ∀ node : (td.subderivation_for_headChoice hc).Node, trg.loaded node.val.facts ->
+  ∃ node2 : (td.subderivation_for_headChoice hc).Node, node ≼ node2 ∧
+  (trg.mapped_head[(hc trg).val]'(by grind)).toSet ⊆ node2.val.facts
 

--- a/ExistentialRules/ChaseSequence/Nontermination/Unblockability.lean
+++ b/ExistentialRules/ChaseSequence/Nontermination/Unblockability.lean
@@ -19,14 +19,152 @@ public section
 
 variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
 
+/-!
+## Another Condition for Obsolescence
+
+For RPC-like conditions we require another property of `ObsolescenceCondition` conditions that does not hold for the general definition.
+The condition shall be stable across certain `GroundTermMapping`s that at least map the head constants to themselves. But this only needs to be true of no fresh term of the trigger already occurs, which, in the context of a chase, means that the trigger itself has not been applied before.
+The reason for excluding this case is a bit technical. Bottom line, we do this as otherwise the property would simply not hold for `SkolemObsolescence`.
+But if a trigger is only obsolete according to `SkolemObsolescence` because it was already applied, then we do not really care. The interesting case is that
+a trigger is obsolete because a disjunct without existentials is already present.
+
+Anyway, at the end you probably don't need to care much about the condition. It is enough to show the desired theorems and as a sanity check,
+we also prove that it holds for both `SkolemObsolescence` and `RestrictedObsolescence` as intended.
+-/
+
+@[expose]
+def ObsolescenceCondition.propagates_under_term_mapping_of_no_fresh_term_occurs (obs : ObsolescenceCondition sig) : Prop := ∀ {trg : PreTrigger sig} {fs : FactSet sig} {h : GroundTermMapping sig}, (∀ i lt t, t ∈ trg.fresh_terms_for_head_disjunct i lt -> t ∉ fs.terms) -> (∀ c ∈ trg.rule.head_constants, h (.const c) = .const c) -> obs.cond trg fs -> obs.cond { rule := trg.rule, subs := h ∘ trg.subs } (h.applyFactSet fs)
+
+theorem SkolemObsolescence.propagates_under_term_mapping_of_no_fresh_term_occurs :
+    (SkolemObsolescence sig).propagates_under_term_mapping_of_no_fresh_term_occurs := by
+  intro trg fs h no_fresh_term_occurs id_const cond
+  simp only [SkolemObsolescence] at cond
+  simp only [SkolemObsolescence]
+  rcases cond with ⟨i, lt, cond⟩
+  exists i, lt
+  intro f f_mem
+  suffices f ∈ h.applyFactSet (trg.mapped_head[i]'(by grind)).toSet by
+    apply TermMapping.apply_generalized_atom_set_subset_of_subset
+    . exact cond
+    . exact this
+  rw [List.mem_toSet] at f_mem
+  unfold PreTrigger.mapped_head at f_mem
+  simp only [List.getElem_map, List.getElem_attach, List.getElem_zipIdx, List.mem_map, Nat.zero_add] at f_mem
+  rcases f_mem with ⟨a, a_mem, f_eq⟩
+  rw [TermMapping.mem_apply_generalized_atom_set]
+  exists trg.apply_to_function_free_atom i lt a; constructor
+  . rw [List.mem_toSet]; simp only [PreTrigger.mapped_head, List.getElem_map, List.getElem_attach, List.getElem_zipIdx, Nat.zero_add, List.mem_map]; exists a
+  . rw [← f_eq, GeneralizedAtom.mk.injEq]
+    simp only [PreTrigger.apply_to_function_free_atom, TermMapping.apply_generalized_atom, true_and]
+    rw [List.map_map, List.map_inj_left]
+    intro voc voc_mem; rw [Function.comp_apply]
+    cases voc with
+    | const c =>
+      rw [PreTrigger.apply_to_var_or_const_for_const]
+      rw [PreTrigger.apply_to_var_or_const_for_const]
+      apply Eq.symm; apply id_const
+      simp only [Rule.head_constants, List.mem_flatMap]; exists trg.rule.head[i]; constructor; exact List.getElem_mem _
+      rw [FunctionFreeConjunction.mem_consts]; exists a
+    | var v =>
+      suffices v ∉ trg.rule.existential_vars_for_head_disjunct i lt by
+        rw [PreTrigger.apply_to_var_or_const_of_not_mem_existential_vars trg _ _ _ this]
+        rw [PreTrigger.apply_to_var_or_const_of_not_mem_existential_vars {rule := trg.rule, subs := h ∘ trg.subs} _ _ _ this]
+        simp
+      intro contra; apply no_fresh_term_occurs i lt (trg.functional_term_for_var i lt v contra)
+      . apply trg.mem_fresh_terms_of_functional_for_exis_var
+      . exists trg.apply_to_function_free_atom i lt a; constructor
+        . apply cond; rw [List.mem_toSet]; simp only [PreTrigger.mapped_head, List.getElem_map, List.getElem_attach, List.getElem_zipIdx, Nat.zero_add, List.mem_map]; exists a
+        . simp only [PreTrigger.apply_to_function_free_atom, TermMapping.apply_generalized_atom]
+          rw [List.mem_map]; exists .var v; constructor; exact voc_mem
+          rw [trg.apply_to_var_or_const_of_mem_existential_vars _ _ _ contra]
+
+theorem RestrictedObsolescence.propagates_under_term_mapping_of_no_fresh_term_occurs :
+    (RestrictedObsolescence sig).propagates_under_term_mapping_of_no_fresh_term_occurs := by
+  intro trg fs h _ id_const cond -- no_fresh_term_occurs is only needed for SkolemObsolescence
+  simp only [RestrictedObsolescence, PreTrigger.satisfied, PreTrigger.satisfied_for_disj] at cond
+  simp only [RestrictedObsolescence, PreTrigger.satisfied, PreTrigger.satisfied_for_disj]
+  rcases cond with ⟨i, lt, cond⟩
+  exists i, lt
+  rcases cond with ⟨s, id_front, cond⟩
+  exists h ∘ s;
+  constructor
+  . intro v v_mem; simp only [Function.comp_apply]; rw [id_front v v_mem]
+  . rw [GroundSubstitution.apply_function_free_conj_compose]
+    . rw [← TermMapping.apply_generalized_atom_set_toSet]
+      apply TermMapping.apply_generalized_atom_set_subset_of_subset
+      exact cond
+    . intro d d_mem; apply id_const
+      simp only [Rule.head_constants, List.mem_flatMap]; exists trg.rule.head[i]; constructor; exact List.getElem_mem _; exact d_mem
+
+
+/-!
+## Unblockability and Overapproximations
+
+We now start to define what it means for a trigger to be unblockable. Also we define the notion of Overapproximation that gives us a way
+of detecting unblockability. Specific such overapproximations will follow later.
+-/
+
+variable {obs : ObsolescenceCondition sig}
+
 /-- A trigger is unblockable for a given `HeadChoice` if, for every derivation, when the trigger is loaded in a node of the branch indicated by the `HeacChoice`, then the `HeadChoice` result of the trigger also occurs in that branch. In the introducing paper this is called g-unblockable. -/
 @[expose]
 def Trigger.unblockable
-    {obs : ObsolescenceCondition sig}
-    (trg : Trigger obs.toLaxObsolescenceCondition)
     (rules : RuleSet sig)
-    (hc : HeadChoice sig) : Prop :=
-  ∀ td : RegularTreeDerivation obs rules, ∀ node : (td.subderivation_for_headChoice hc).Node, trg.loaded node.val.facts ->
-  ∃ node2 : (td.subderivation_for_headChoice hc).Node, node ≼ node2 ∧
+    (hc : HeadChoice sig)
+    (trg : Trigger obs.toLaxObsolescenceCondition) : Prop :=
+  ∀ kb : KnowledgeBase sig, kb.rules = rules ->
+  ∀ ct : RegularChaseTree obs kb, ∀ node : (ct.subderivation_for_headChoice hc).Node, trg.loaded node.val.facts ->
+  ∃ node2 : (ct.subderivation_for_headChoice hc).Node, node ≼ node2 ∧
   (trg.output_for_headChoice hc).toSet ⊆ node2.val.facts
+
+/-- This is Definition 7 from the [RPC] paper. -/
+def FactSet.is_rpc_overapproximation
+    (rules : RuleSet sig)
+    (hc : HeadChoice sig)
+    (trg : Trigger obs.toLaxObsolescenceCondition)
+    (fs : FactSet sig) : Prop :=
+  ∃ h : GroundTermMapping sig, (∀ c ∈ trg.rule.head_constants, h (.const c) = .const c) ∧ (∀ t ∈ trg.mapped_frontier, h t = t) ∧
+    ∀ kb : KnowledgeBase sig, kb.rules = rules ->
+    ∀ ct : RegularChaseTree obs kb, ∀ node ∈ (ct.subderivation_for_headChoice hc).toChaseDerivation,
+      (¬ (trg.output_for_headChoice hc).toSet ⊆ node.facts) -> h.applyFactSet node.facts ⊆ fs
+
+/-- This is Lemma 1 from the [RPC] paper. -/
+theorem PreTrigger.unblockable_of_not_obsolete_for_overapproximation
+    (obs_propagates : obs.propagates_under_term_mapping_of_no_fresh_term_occurs)
+    {rules : RuleSet sig} {hc : HeadChoice sig}
+    (hc_consistent : hc.consistent_for_equivalent_triggers)
+    {trg : RTrigger obs rules} {fs : FactSet sig} :
+    fs.is_rpc_overapproximation rules hc trg.val -> ¬ obs.cond trg.val fs -> trg.val.unblockable rules hc := by
+  intro ⟨h, id_head_consts, id_frontier, overapprox⟩ not_obs
+  intro kb rules_eq ct node loaded
+  let trg_kb : RTrigger obs kb.rules := ⟨trg.val, by rw [rules_eq]; exact trg.property⟩
+  suffices ∃ node2, node ≼ node2 ∧ ¬ trg.val.active node2.val.facts by
+    rcases this with ⟨node2, prec, not_active⟩
+    exists node2; constructor; exact prec
+    apply Classical.byContradiction
+    intro contra
+    apply not_active; constructor; exact Set.subset_trans loaded (RegularChaseDerivationSkeleton.facts_node_subset_of_prec prec)
+    intro is_obs; apply not_obs
+    suffices obs.cond trg.val (h.applyFactSet node2.val.facts) by
+      apply LaxObsolescenceCondition.monotone _ _ this
+      apply overapprox _ rules_eq _ _ node2.property
+      exact contra
+    apply (obs.preserved_under_equiv _).mp (obs_propagates _ _ is_obs)
+    . apply PreTrigger.equiv_of_rule_eq_of_mapped_frontier_equiv; rfl
+      rw [← PreTrigger.apply_mapping_after_mapped_frontier]
+      apply List.map_id_of_id_on_all_mem; exact id_frontier
+    . intro i lt t t_fresh t_mem_node2; apply contra
+      rcases RegularChaseBranch.trigger_introducing_functional_term_occurs_in_chase node2 t_mem_node2 (trg := trg_kb) t_fresh with ⟨node3, node3_prec, orig, orig_mem, equiv, headIdx_eq⟩
+      apply Set.subset_trans _ (RegularChaseDerivationSkeleton.facts_node_subset_of_prec node3_prec)
+      rw [← PreTrigger.output_for_headChoice_eq_of_equiv hc_consistent equiv]; simp only [PreTrigger.output_for_headChoice]
+      suffices RegularChaseNode.regularChaseNodeInstance.adheres_to_headChoice node3.val hc by
+        simp only [← this orig orig_mem]
+        exact node3.val.facts_contain_origin_result orig orig_mem
+      apply ct.subderivation_for_headChoice_adheres_to_headChoice
+      exact node3.property
+    . exact id_head_consts
+  rcases RegularChaseDerivation.fairness_prec (cd := (ct.subderivation_for_headChoice hc).toChaseDerivation) trg_kb with ⟨fairness_node, fair⟩
+  cases ChaseDerivationSkeleton.predecessor_total node fairness_node with
+  | inl prec => exists fairness_node; constructor; exact prec; apply fair; grind
+  | inr prec => exists node; constructor; grind; apply fair; exact prec
 

--- a/ExistentialRules/ChaseSequence/Termination/BacktrackingOfFacts/PreGroundTerm.lean
+++ b/ExistentialRules/ChaseSequence/Termination/BacktrackingOfFacts/PreGroundTerm.lean
@@ -273,10 +273,9 @@ mutual
             apply Or.inl
             rw [List.mem_flatMap] at c_mem
             rcases c_mem with ⟨t, t_mem, c_mem⟩
+            unfold PreTrigger.mapped_frontier at t_mem
             rw [List.mem_map] at t_mem
             rcases t_mem with ⟨v, v_mem, t_eq⟩
-            unfold PreTrigger.subs_for_mapped_head at t_eq
-            rw [PreTrigger.apply_to_var_or_const_frontier_var _ _ func.headIdx_lt v v_mem] at t_eq
             simp only [trg, backtrackTrigger] at v_mem
             simp only [trg, backtrackTrigger, v_mem, ↓reduceDIte] at t_eq
             rw [← t_eq] at c_mem

--- a/ExistentialRules/ChaseSequence/Termination/BacktrackingOfFacts/PreTrigger.lean
+++ b/ExistentialRules/ChaseSequence/Termination/BacktrackingOfFacts/PreTrigger.lean
@@ -45,7 +45,7 @@ theorem backtrackTrigger_for_functional_term_equiv
   simp only [backtrackTrigger_for_functional_term, PreTrigger.functional_term_for_var, GroundTerm.backtrackTrigger, GroundTerm.func, PreGroundTerm.backtrackTrigger]
   simp only [PreTrigger.equiv, true_and]
   intro u u_mem
-  simp only [u_mem, ↓reduceDIte]
+  simp only [u_mem, ↓reduceDIte, PreTrigger.mapped_frontier]
   rw [Subtype.mk.injEq]
   rw [List.getElem_unattach, List.getElem_map]
   rw [List.getElem_idxOf_of_mem]

--- a/ExistentialRules/ChaseSequence/Termination/ConstantMappings/Basic.lean
+++ b/ExistentialRules/ChaseSequence/Termination/ConstantMappings/Basic.lean
@@ -171,7 +171,7 @@ theorem apply_fact_swap_apply_to_function_free_atom (g : ConstantMapping sig) (t
   | const d => simpa using h d (by simpa using voc_mem)
   | var v =>
     cases Decidable.em (v ∈ trg.rule.existential_vars_for_head_disjunct i lt) with
-    | inl v_mem => simp [v_mem, PreTrigger.functional_term_for_var]
+    | inl v_mem => simp [v_mem, PreTrigger.functional_term_for_var, PreTrigger.apply_mapping_after_mapped_frontier]
     | inr v_mem => simp [v_mem]
 
 /-- Mapping the same fact using two `ConstantMapping`s yields the same fact if the mappings agree on all constants of the fact. -/

--- a/ExistentialRules/ChaseSequence/Termination/ConstantMappings/InterplayWithBacktracking/BacktrackingOfLoadedTriggerInNode.lean
+++ b/ExistentialRules/ChaseSequence/Termination/ConstantMappings/InterplayWithBacktracking/BacktrackingOfLoadedTriggerInNode.lean
@@ -116,9 +116,7 @@ theorem backtracking_of_term_in_node [GetFreshInhabitant sig.C] [Inhabited sig.C
 
         rcases PreTrigger.mem_fresh_terms _ term_mem with ⟨v, v_mem, term_functional⟩
 
-        let mapped_frontier := origin.fst.val.rule.frontier.map origin.fst.val.subs
-
-        have : ∀ sublist, (sub : sublist ⊆ mapped_frontier) -> ∀ forbidden_constants, (sublist.flatMap GroundTerm.constants ⊆ forbidden_constants) -> ((sublist.flatMap GroundTerm.rules).flatMap Rule.constants ⊆ forbidden_constants) -> ∃ (g : ConstantMapping sig),
+        have : ∀ sublist, (sub : sublist ⊆ origin.fst.val.mapped_frontier) -> ∀ forbidden_constants, (sublist.flatMap GroundTerm.constants ⊆ forbidden_constants) -> ((sublist.flatMap GroundTerm.rules).flatMap Rule.constants ⊆ forbidden_constants) -> ∃ (g : ConstantMapping sig),
             (g.apply_fact_set (PreGroundTerm.backtrackFacts_list sublist.unattach
               (by simp only [List.mem_unattach]; rintro _ ⟨h, _⟩; exact h)
               forbidden_constants).fst.toSet ⊆ next.facts) ∧
@@ -139,15 +137,9 @@ theorem backtracking_of_term_in_node [GetFreshInhabitant sig.C] [Inhabited sig.C
 
             rcases ih hd (by
               rw [List.cons_subset] at sub
-              unfold mapped_frontier at sub
-              rw [List.mem_map] at sub
-              rcases sub.left with ⟨v, v_mem, hd_eq⟩
               apply FactSet.terms_subset_of_subset origin_active.left
-              rw [FactSet.mem_terms_toSet, PreTrigger.mem_terms_mapped_body_iff]
-              apply Or.inr
-              exists v; constructor
-              . apply Rule.frontier_subset_vars_body; exact v_mem
-              . exact hd_eq
+              rw [FactSet.mem_terms_toSet]
+              exact PreTrigger.mem_terms_mapped_body_of_mem_mapped_frontier _ sub.left
             ) forbidden_constants forbidden_constants_subsumes_term.left (by
               apply Set.subset_trans _ forbidden_constants_subsumes_rules
               rw [List.flatMap_cons, List.flatMap_append]; apply List.subset_append_of_subset_left
@@ -249,7 +241,7 @@ theorem backtracking_of_term_in_node [GetFreshInhabitant sig.C] [Inhabited sig.C
           origin.fst.val.backtrackTrigger_for_functional_term forbidden_constants origin.snd.val origin.snd.isLt v v_mem
 
         have triggers_equiv : backtrack_trigger.equiv origin.fst.val := by apply origin.fst.val.backtrackTrigger_for_functional_term_equiv
-        rcases this mapped_frontier (by simp) (forbidden_constants ++ fresh_consts_for_pure_body_vars)
+        rcases this origin.fst.val.mapped_frontier (by simp) (forbidden_constants ++ fresh_consts_for_pure_body_vars)
           (by apply List.subset_append_of_subset_left
               intro d d_mem
               apply forbidden_constants_subsumes_term
@@ -425,11 +417,11 @@ theorem backtracking_of_term_in_node [GetFreshInhabitant sig.C] [Inhabited sig.C
                 cases this with
                 | inl d_mem'' =>
                   apply d_not_forbidden; apply forbidden_constants_subsumes_rules;
-                  suffices d ∈ (mapped_frontier.flatMap GroundTerm.rules).flatMap Rule.constants by
+                  suffices d ∈ (origin.fst.val.mapped_frontier.flatMap GroundTerm.rules).flatMap Rule.constants by
                     rw [term_functional, GroundTerm.rules_func]
                     rw [List.flatMap_cons]; apply List.mem_append_right
                     exact this
-                  have : mapped_frontier.flatMap GroundTerm.rules = (mapped_frontier.unattach.flatMap FiniteTree.innerLabels).map SkolemFS.rule := by rw [List.flatMap_unattach, List.map_flatMap]; rfl
+                  have : origin.fst.val.mapped_frontier.flatMap GroundTerm.rules = (origin.fst.val.mapped_frontier.unattach.flatMap FiniteTree.innerLabels).map SkolemFS.rule := by rw [List.flatMap_unattach, List.map_flatMap]; rfl
                   rw [this, List.flatMap_map]
                   exact d_mem''
                 | inr d_mem'' =>

--- a/ExistentialRules/ChaseSequence/Termination/ConstantMappings/InterplayWithObsolescenceCondition.lean
+++ b/ExistentialRules/ChaseSequence/Termination/ConstantMappings/InterplayWithObsolescenceCondition.lean
@@ -65,28 +65,10 @@ theorem RestrictedObsolescence.propagates_under_constant_mapping : (RestrictedOb
   exists g.apply_ground_term ∘ s
   constructor
   . intro v v_mem; simp only [Function.comp_apply]; rw [id_front v v_mem]
-  . unfold GroundSubstitution.apply_function_free_conj
-    unfold TermMapping.apply_generalized_atom_list
-    intro f f_mem
-    rw [List.mem_toSet, List.mem_map] at f_mem
-    rcases f_mem with ⟨a, a_mem, f_eq⟩
-    rw [← GroundSubstitution.apply_function_free_atom.eq_def, GroundSubstitution.apply_function_free_atom_compose] at f_eq
-    . rw [← f_eq]
-      rw [← ConstantMapping.apply_fact_eq_groundTermMapping_applyFact]
-      apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_set
-      apply cond
-      rw [List.mem_toSet]
-      apply List.mem_map_of_mem
-      exact a_mem
-    . intro d d_mem
-      conv => left; simp only [ConstantMapping.apply_ground_term, ConstantMapping.apply_pre_ground_term, GroundTerm.const, FiniteTree.mapLeaves]
-      apply g_id
-      unfold Rule.head_constants
-      rw [List.mem_flatMap]
-      exists trg.rule.head[i]
-      constructor
-      . apply List.getElem_mem
-      . unfold FunctionFreeConjunction.consts
-        rw [List.mem_flatMap]
-        exists a
+  . rw [GroundSubstitution.apply_function_free_conj_compose]
+    . rw [← TermMapping.apply_generalized_atom_set_toSet]
+      apply TermMapping.apply_generalized_atom_set_subset_of_subset
+      exact cond
+    . intro d d_mem; rw [ConstantMapping.apply_ground_term_constant]; apply g_id
+      simp only [Rule.head_constants, List.mem_flatMap]; exists trg.rule.head[i]; constructor; exact List.getElem_mem _; exact d_mem
 

--- a/ExistentialRules/ChaseSequence/Termination/Linear.lean
+++ b/ExistentialRules/ChaseSequence/Termination/Linear.lean
@@ -844,7 +844,7 @@ section SubstitutionsAndTriggers
     unfold GroundTerm.func
     simp only [Subtype.mk.injEq, FiniteTree.inner.injEq, exists_and_left, exists_prop,
       exists_eq_left']
-    exists (List.map trg.subs trg.rule.frontier)
+    exists trg.mapped_frontier
     simp [SkolemFS.arity]
 
    /--If i is a position in the second rule head containing a non-frontier-variable (i.e. an existential variable),then `ruleApply` will map the term at this position to a functional term (a SkolemFunction)-/
@@ -876,7 +876,7 @@ section SubstitutionsAndTriggers
     unfold GroundTerm.func
     simp only [Subtype.mk.injEq, FiniteTree.inner.injEq, exists_and_left, exists_prop,
       exists_eq_left']
-    exists (List.map trg.subs trg.rule.frontier)
+    exists trg.mapped_frontier
     simp [SkolemFS.arity]
 
 end SubstitutionsAndTriggers

--- a/ExistentialRules/ChaseSequence/Termination/MfaLike.lean
+++ b/ExistentialRules/ChaseSequence/Termination/MfaLike.lean
@@ -205,7 +205,7 @@ theorem DeterministicSkolemObsolescence.blocks_each_obs (obs : ObsolescenceCondi
     | var v =>
       simp only [Function.comp_apply, StrictConstantMapping.apply_var_or_const]
       cases Decidable.em (v ∈ trg.val.rule.existential_vars_for_head_disjunct i lt) with
-      | inl v_mem => simp [v_mem, PreTrigger.functional_term_for_var]
+      | inl v_mem => simp [v_mem, PreTrigger.functional_term_for_var, PreTrigger.apply_mapping_after_mapped_frontier]
       | inr v_mem => simp [v_mem]
     | const c => simp [StrictConstantMapping.apply_var_or_const, PreTrigger.apply_to_var_or_const_for_const, ConstantMapping.apply_ground_term_constant, StrictConstantMapping.toConstantMapping]
 

--- a/ExistentialRules/ChaseSequence/Termination/ParallelDeterminizedChase.lean
+++ b/ExistentialRules/ChaseSequence/Termination/ParallelDeterminizedChase.lean
@@ -192,32 +192,10 @@ theorem parallelDeterminizedDerivation_constants :
           apply ih
           rw [List.mem_flatMap] at c_mem
           rcases c_mem with ⟨t, t_mem, c_mem⟩
-          rw [List.mem_map] at t_mem
-          rcases t_mem with ⟨v, v_mem, t_mem⟩
-          rcases FunctionFreeConjunction.mem_vars.mp (trg.val.rule.frontier_subset_vars_body v_mem) with ⟨a, a_mem, v_mem'⟩
-          exists trg.val.subs.apply_function_free_atom a
-          constructor
-          . apply trg_act.left
-            rw [List.mem_toSet]
-            unfold PreTrigger.mapped_body
-            unfold GroundSubstitution.apply_function_free_conj
-            apply List.mem_map_of_mem
-            exact a_mem
-          . unfold Fact.constants
-            rw [List.mem_flatMap]
-            exists t
-            constructor
-            . unfold GroundSubstitution.apply_function_free_atom
-              unfold TermMapping.apply_generalized_atom
-              rw [List.mem_map]
-              exists VarOrConst.var v
-              constructor
-              . exact v_mem'
-              . unfold PreTrigger.subs_for_mapped_head at t_mem
-                rw [PreTrigger.apply_to_var_or_const_frontier_var] at t_mem
-                . exact t_mem
-                . exact v_mem
-            . exact c_mem
+          apply FactSet.constants_subset_of_subset trg_act.left
+          rw [FactSet.mem_constants_iff_mem_terms]; exists t; constructor
+          . rw [FactSet.mem_terms_toSet]; apply PreTrigger.mem_terms_mapped_body_of_mem_mapped_frontier; exact t_mem
+          . exact c_mem
         | inr c_mem =>
           apply Or.inl
           exists trg.val.rule
@@ -304,25 +282,13 @@ theorem parallelDeterminizedDerivation_functions :
               exact v_mem
         | inr func_mem =>
           apply ih
-          simp only [List.mem_flatMap, List.mem_map] at func_mem; rcases func_mem with ⟨t, ⟨v, v_mem, t_mem⟩, func_mem⟩
-          rcases FunctionFreeConjunction.mem_vars.mp (Rule.frontier_subset_vars_body v_mem) with ⟨body_atom, body_atom_mem, frontier_var_mem⟩
-          exists (trg.val.subs.apply_function_free_atom body_atom)
+          simp only [List.mem_flatMap] at func_mem; rcases func_mem with ⟨t, t_mem, func_mem⟩
+          have t_mem_body := trg.val.mem_terms_mapped_body_of_mem_mapped_frontier _ t_mem
+          rw [List.mem_flatMap] at t_mem_body; rcases t_mem_body with ⟨f, f_mem, t_mem⟩
+          exists f
           constructor
-          . apply trg_act.left
-            rw [List.mem_toSet]
-            simp only [PreTrigger.mapped_body, GroundSubstitution.apply_function_free_conj, TermMapping.apply_generalized_atom_list]
-            rw [List.mem_map]
-            exists body_atom
-          . unfold Fact.function_symbols
-            rw [List.mem_flatMap]
-            exists (trg.val.subs v)
-            constructor
-            . unfold GroundSubstitution.apply_function_free_atom
-              unfold TermMapping.apply_generalized_atom
-              rw [List.mem_map]
-              exists VarOrConst.var v
-            . rw [← t_mem] at func_mem
-              exact func_mem
+          . apply trg_act.left; rw [List.mem_toSet]; exact f_mem
+          . exact List.mem_flatMap_of_mem t_mem func_mem
 
 /-- All predicates in the derivation result come from the rules or the starting fact set. -/
 theorem parallelDeterminizedDerivation_result_predicates :

--- a/ExistentialRules/ChaseSequence/TreeDerivation.lean
+++ b/ExistentialRules/ChaseSequence/TreeDerivation.lean
@@ -1233,31 +1233,10 @@ theorem constants_node_subset_constants_fs_union_constants_rules
       apply Or.inl
       rw [List.mem_flatMap] at d_mem
       rcases d_mem with ⟨t, t_mem, d_mem⟩
-      rw [List.mem_map] at t_mem
-      rcases t_mem with ⟨v, v_mem, t_mem⟩
-      rcases FunctionFreeConjunction.mem_vars.mp (origin.fst.val.rule.frontier_subset_vars_body v_mem) with ⟨a, a_mem, v_mem'⟩
-      exists origin.fst.val.subs.apply_function_free_atom a
-      constructor
-      . have := active_trigger_origin_of_mem_childNodes next_mem
-        apply this.left
-        unfold PreTrigger.mapped_body
-        rw [List.mem_toSet]
-        apply TermMapping.apply_generalized_atom_mem_apply_generalized_atom_list
-        exact a_mem
-      . unfold Fact.constants
-        rw [List.mem_flatMap]
-        exists t
-        constructor
-        . unfold GroundSubstitution.apply_function_free_atom
-          unfold TermMapping.apply_generalized_atom
-          rw [List.mem_map]
-          exists VarOrConst.var v
-          constructor
-          . exact v_mem'
-          . unfold PreTrigger.subs_for_mapped_head at t_mem
-            rw [PreTrigger.apply_to_var_or_const_frontier_var _ _ _ _ v_mem] at t_mem
-            exact t_mem
-        . exact d_mem
+      apply FactSet.constants_subset_of_subset (active_trigger_origin_of_mem_childNodes next_mem).left
+      rw [FactSet.mem_constants_iff_mem_terms]; exists t; constructor
+      . rw [FactSet.mem_terms_toSet]; apply PreTrigger.mem_terms_mapped_body_of_mem_mapped_frontier; exact t_mem
+      . exact d_mem
     | inr d_mem =>
       apply Or.inr
       exists origin.fst.val.rule

--- a/ExistentialRules/Models/Cores.lean
+++ b/ExistentialRules/Models/Cores.lean
@@ -549,22 +549,13 @@ theorem strong_core_of_model_is_model
       rw [frontier_mapping v v_mem]
       rw [Function.comp_apply]
       rw [inv_id _ (by
-        unfold Rule.frontier at v_mem
-        rw [List.mem_filter] at v_mem
-        have v_mem := v_mem.left
-        rw [FunctionFreeConjunction.mem_vars] at v_mem
-        rcases v_mem with ⟨a, a_mem, v_mem⟩
-        exists subs.apply_function_free_atom a
-        constructor
-        . apply loaded
-          unfold GroundSubstitution.apply_function_free_conj
-          unfold TermMapping.apply_generalized_atom_list
-          rw [List.mem_toSet, List.mem_map]
-          exists a
-        . unfold GroundSubstitution.apply_function_free_atom
-          unfold TermMapping.apply_generalized_atom
-          rw [List.mem_map]
-          exists VarOrConst.var v
+        have v_mem_body := r.frontier_subset_vars_body v_mem
+        rw [FunctionFreeConjunction.mem_vars] at v_mem_body; rcases v_mem_body with ⟨a, a_mem, v_mem_body⟩
+        apply FactSet.terms_subset_of_subset loaded
+        rw [FactSet.mem_terms_toSet]
+        apply List.mem_flatMap_of_mem (TermMapping.apply_generalized_atom_mem_apply_generalized_atom_list _ _ _ a_mem)
+        simp [TermMapping.apply_generalized_atom]
+        exists .var v
       )]
     . apply Set.subset_trans (b := h_fs_sc.applyFactSet fs)
       . intro f f_mem

--- a/ExistentialRules/Triggers/Basic.lean
+++ b/ExistentialRules/Triggers/Basic.lean
@@ -33,6 +33,19 @@ namespace PreTrigger
 
 variable {sig : Signature} [DecidableEq sig.P] [DecidableEq sig.C] [DecidableEq sig.V]
 
+/-- The `mapped_frontier` results from applying the triggers substitution to all frontier variables. -/
+@[expose]
+def mapped_frontier (trg : PreTrigger sig) : List (GroundTerm sig) := trg.rule.frontier.map trg.subs
+
+/-- The lenth of the `mapped_frontier` is exactly the length of the frontier. -/
+@[simp, grind =]
+theorem length_mapped_frontier {trg : PreTrigger sig} : trg.mapped_frontier.length = trg.rule.frontier.length := by simp [mapped_frontier]
+
+/-- Applying a term mapping after the trigger can be combined with the substitution without affecting the `mapped_frontier`. -/
+theorem apply_mapping_after_mapped_frontier {trg : PreTrigger sig} {mapping : TermMapping (GroundTerm sig) (GroundTerm sig)} :
+    trg.mapped_frontier.map mapping = {rule := trg.rule, subs := mapping ∘ trg.subs : PreTrigger sig}.mapped_frontier := by
+  simp [mapped_frontier]
+
 /-- In the context of a trigger, we Skolemize a `VarOrConst` by passing the rule in the trigger. -/
 def skolemize_var_or_const (trg : PreTrigger sig) (i : Nat) (lt : i < trg.rule.head.length) (var_or_const : VarOrConst sig) : SkolemTerm sig :=
   var_or_const.skolemize trg.rule i lt
@@ -72,8 +85,8 @@ def functional_term_for_var
     GroundTerm sig :=
   GroundTerm.func
     { rule := trg.rule, headIdx := i, headIdx_lt := lt, v, v_mem }
-    (trg.rule.frontier.map trg.subs)
-    (by rw [List.length_map]; rfl)
+    trg.mapped_frontier
+    (by rw [length_mapped_frontier]; rfl)
 
 /-- The `functional_term_for_var` function is injective for a fixed trigger. -/
 @[grind ->]
@@ -100,8 +113,7 @@ theorem functional_term_for_var.injEq
 theorem apply_to_var_or_const_of_mem_existential_vars (trg : PreTrigger sig) (i : Nat) (lt : i < trg.rule.head.length) :
     ∀ v, (mem : v ∈ trg.rule.existential_vars_for_head_disjunct i lt) ->
     trg.apply_to_var_or_const i lt (.var v) = trg.functional_term_for_var i lt v mem := by
-  intro v v_mem
-  simp [functional_term_for_var, apply_to_var_or_const, skolemize_var_or_const, VarOrConst.skolemize, v_mem, GroundSubstitution.apply_skolem_term]
+  intro v v_mem; simp [functional_term_for_var, apply_to_var_or_const, skolemize_var_or_const, VarOrConst.skolemize, v_mem, GroundSubstitution.apply_skolem_term, mapped_frontier]
 
 /-- For existential variables, applying the trigger is injective. -/
 theorem apply_to_var_or_const_injective_of_mem_existential_vars {v : sig.V}
@@ -118,24 +130,22 @@ theorem apply_to_var_or_const_injective_of_mem_existential_vars {v : sig.V}
       rw [apply_to_var_or_const_of_mem_existential_vars _ _ _ _ v_mem, apply_to_var_or_const_of_not_mem_existential_vars _ _ _ _ u_mem] at apply_eq
       unfold functional_term_for_var at apply_eq
       have u_front : u ∈ trg.rule.frontier := by
-        unfold Rule.existential_vars_for_head_disjunct at u_mem; rw [List.mem_filter, not_and, decide_not, not_decide_eq_true, Decidable.not_not] at u_mem
-        apply u_mem
-        rw [FunctionFreeConjunction.mem_vars']
-        exact voc_mem
-      have : trg.subs u ∈ trg.rule.frontier.map trg.subs := List.mem_map_of_mem u_front
+        apply trg.rule.mem_frontier_of_mem_head_disjunct_of_not_mem_existential_vars _ _ u_mem
+        rw [FunctionFreeConjunction.mem_vars']; exact voc_mem
+      have : trg.subs u ∈ trg.mapped_frontier := List.mem_map_of_mem u_front
       rw [← apply_eq] at this
       exact GroundTerm.eq_while_contained_is_impossible this
 
 /-- Applying the trigger to non-frontier variables yields a term that cannot possibly be in the mapped frontier. In other words, terms for existential variables are fresh (although freshness entails more than that). -/
 theorem result_term_not_in_frontier_image_of_var_existential (trg : PreTrigger sig) (i : Nat) (lt : i < trg.rule.head.length)
     (v : sig.V) (v_existential : v ∈ trg.rule.existential_vars_for_head_disjunct i lt) :
-    ¬ trg.apply_to_var_or_const i lt (VarOrConst.var v) ∈ (trg.rule.frontier).map trg.subs := by
+    ¬ trg.apply_to_var_or_const i lt (VarOrConst.var v) ∈ trg.mapped_frontier := by
   intro contra
-  rw [List.mem_map] at contra
+  simp only [mapped_frontier, List.mem_map] at contra
   rcases contra with ⟨u, u_in_frontier, u_eq⟩
   rw [apply_to_var_or_const_of_mem_existential_vars _ _ _ _ v_existential] at u_eq
   unfold functional_term_for_var at u_eq
-  have : trg.subs u ∈ trg.rule.frontier.map trg.subs := List.mem_map_of_mem u_in_frontier
+  have : trg.subs u ∈ trg.mapped_frontier := List.mem_map_of_mem u_in_frontier
   rw [u_eq] at this
   exact GroundTerm.eq_while_contained_is_impossible this
 
@@ -200,6 +210,12 @@ theorem mem_terms_mapped_body_iff (trg : PreTrigger sig) :
       . simp only [TermMapping.apply_generalized_atom]
         rw [List.mem_map]
         exists VarOrConst.var v
+
+/-- If a term is in `the mapped_frontier`, then it is also in the `mapped_body`. -/
+theorem mem_terms_mapped_body_of_mem_mapped_frontier {trg : PreTrigger sig} :
+    ∀ t ∈ trg.mapped_frontier, t ∈ trg.mapped_body.flatMap GeneralizedAtom.terms := by
+  simp only [mapped_frontier, List.mem_map]; intro t ⟨v, v_mem, t_mem⟩
+  rw [mem_terms_mapped_body_iff]; apply Or.inr; exact ⟨v, trg.rule.frontier_subset_vars_body v_mem, t_mem⟩
 
 /-- The mapped head is the result of the trigger and is simply the application to all head atoms. This result has a list of result facts for each of the head disjuncts. Note again that existential variables are Skolemized before the trigger's substitution is applied but this is hidden within the previously defined functions. -/
 @[expose, implicit_reducible]
@@ -267,7 +283,7 @@ theorem mem_fresh_terms_of_functional_for_exis_var {trg : PreTrigger sig} {i : N
 /-- This theorem unfolds some of the internal definitions of `fresh_terms_for_head_disjunct`. -/
 theorem mem_fresh_terms {trg : PreTrigger sig} {i : Nat} {lt : i < trg.rule.head.length} :
     ∀ t ∈ trg.fresh_terms_for_head_disjunct i lt, ∃ (v : sig.V) (v_mem : v ∈ trg.rule.existential_vars_for_head_disjunct i lt),
-    t = GroundTerm.func { rule := trg.rule, headIdx := i, headIdx_lt := lt, v, v_mem } (trg.rule.frontier.map trg.subs) (by rw [List.length_map]; rfl) := by
+    t = GroundTerm.func { rule := trg.rule, headIdx := i, headIdx_lt := lt, v, v_mem } trg.mapped_frontier (by rw [length_mapped_frontier]; rfl) := by
   intro t t_mem
   simp only [fresh_terms_for_head_disjunct, List.mem_map, functional_term_for_var, List.mem_attach] at t_mem
   rcases t_mem with ⟨⟨v, v_mem⟩, _, t_mem⟩
@@ -289,7 +305,7 @@ theorem constant_not_mem_fresh_terms_for_head_disjunct {trg : PreTrigger sig} {i
 
 /-- Mappings of frontier variables can never be fresh. -/
 theorem frontier_term_not_mem_fresh_terms_for_head_disjunct {trg : PreTrigger sig} {i : Nat} {lt : i < trg.rule.head.length} :
-    ∀ {t}, t ∈ trg.rule.frontier.map trg.subs -> ¬ t ∈ trg.fresh_terms_for_head_disjunct i lt := by
+    ∀ {t}, t ∈ trg.mapped_frontier -> ¬ t ∈ trg.fresh_terms_for_head_disjunct i lt := by
   intro t t_frontier t_fresh
   simp only [fresh_terms_for_head_disjunct, List.mem_map, List.mem_attach] at t_fresh
   rcases t_fresh with ⟨⟨v, v_mem⟩, _, t_fresh⟩
@@ -441,10 +457,7 @@ theorem mem_terms_mapped_head_iff (trg : PreTrigger sig) (i : Nat) (lt : i < trg
             rw [FunctionFreeConjunction.mem_vars', ← eq]
             apply var_or_const_for_result_term_mem_terms_head
           apply trg.rule.mem_frontier_for_head_of_mem_frontier_of_mem_head_terms _ _ (by rw [← FunctionFreeConjunction.mem_vars']; exact v_mem_head)
-          unfold Rule.existential_vars_for_head_disjunct at v_not_exis
-          rw [List.mem_filter, not_and, decide_not, not_decide_eq_true, Decidable.not_not] at v_not_exis
-          apply v_not_exis
-          exact v_mem_head
+          exact trg.rule.mem_frontier_of_mem_head_disjunct_of_not_mem_existential_vars _ v_mem_head v_not_exis
         . rw [apply_to_var_or_const_of_not_mem_existential_vars _ _ _ _ v_not_exis]
   . intro h
     cases h with
@@ -489,7 +502,7 @@ theorem mem_terms_mapped_head_iff (trg : PreTrigger sig) (i : Nat) (lt : i < trg
 
 /-- The constants in the trigger result are a subset of the constants from the mapped frontier terms and the constants that occur directly in the rule head. -/
 theorem mapped_head_constants_subset (trg : PreTrigger sig) (i : Nat) (lt : i < trg.rule.head.length) :
-    FactSet.constants (trg.mapped_head[i]'(by grind)).toSet ⊆ (((trg.rule.frontier.map (trg.subs_for_mapped_head i lt)).flatMap GroundTerm.constants) ++ trg.rule.head[i].consts).toSet := by
+    FactSet.constants (trg.mapped_head[i]'(by grind)).toSet ⊆ ((trg.mapped_frontier.flatMap GroundTerm.constants) ++ trg.rule.head[i].consts).toSet := by
   intro c c_mem
   rw [List.mem_toSet, List.mem_append]
   rw [FactSet.mem_constants_toSet, List.mem_flatMap] at c_mem
@@ -513,21 +526,15 @@ theorem mapped_head_constants_subset (trg : PreTrigger sig) (i : Nat) (lt : i < 
     rw [List.mem_flatMap]; exists t; constructor
     . have v_mem : v ∈ trg.rule.frontier := by
         apply Rule.mem_frontier_iff_mem_frontier_for_head.mpr; exact ⟨_, ⟨_, v_mem⟩⟩
-      rw [List.mem_map]; exists v; constructor;
-      . exact v_mem
-      . unfold subs_for_mapped_head; rw [apply_to_var_or_const_frontier_var]; exact t_mem; exact v_mem
+      rw [← t_mem]; apply List.mem_map_of_mem; exact v_mem
     . exact c_mem
   | inr t_mem =>
     apply Or.inl
     simp only [fresh_terms_for_head_disjunct, List.mem_map] at t_mem; rcases t_mem with ⟨v, v_mem, t_mem⟩
     rw [← t_mem] at c_mem
-    simp only [functional_term_for_var, GroundTerm.constants_func, List.mem_flatMap, List.mem_map] at c_mem
-    rcases c_mem with ⟨t, ⟨v, v_mem, t_eq⟩, t_mem⟩
-    simp only [List.mem_flatMap, List.mem_map]
-    exists t; constructor; exists v; constructor
-    . exact v_mem
-    . unfold subs_for_mapped_head; rw [apply_to_var_or_const_frontier_var]; exact t_eq; exact v_mem
-    . exact t_mem
+    simp only [functional_term_for_var, GroundTerm.constants_func, List.mem_flatMap] at c_mem
+    rcases c_mem with ⟨t, t_mem, c_mem⟩
+    simp only [List.mem_flatMap]; exists t
 
 /-- The trigger is loaded for a `FactSet` if its mapped body occurs in the fact set. -/
 @[expose]
@@ -604,6 +611,19 @@ theorem equiv_symm {trg1 trg2 : PreTrigger sig} : trg1.equiv trg2 -> trg2.equiv 
 @[grind ->]
 theorem equiv_trans {trg1 trg2 trg3 : PreTrigger sig} : trg1.equiv trg2 -> trg2.equiv trg3 -> trg1.equiv trg3 := by unfold equiv; grind
 
+/-- Equivalent triggers have the same `mapped_frontier`. -/
+theorem mapped_frontier_eq_of_equiv {trg1 trg2 : PreTrigger sig} (equiv : trg1.equiv trg2) : trg1.mapped_frontier = trg2.mapped_frontier := by
+  unfold mapped_frontier
+  rw [← equiv.left, List.map_inj_left]
+  exact equiv.right
+
+/-- Two triggers with same rule and same mapped_frontier are equivalent. -/
+theorem equiv_of_rule_eq_of_mapped_frontier_equiv {trg1 trg2 : PreTrigger sig}
+    (rule_eq : trg1.rule = trg2.rule) (mapped_front_eq : trg1.mapped_frontier = trg2.mapped_frontier) : trg1.equiv trg2 := by
+  constructor; exact rule_eq
+  unfold mapped_frontier at mapped_front_eq; rw [← rule_eq, List.map_inj_left] at mapped_front_eq
+  exact mapped_front_eq
+
 /-- We consider two trigger to be strongly equivalent if they share the same rule and their substitutions agree not only on the frontier variables but on all body variables. -/
 @[expose]
 def strong_equiv (trg1 trg2 : PreTrigger sig) : Prop :=
@@ -674,19 +694,12 @@ theorem apply_to_function_free_atom_eq_of_equiv {trg1 trg2 : PreTrigger sig} (eq
       simp only [equiv.left] at v_exis
       rw [trg2.apply_to_var_or_const_of_mem_existential_vars _ _ _ v_exis]
       unfold PreTrigger.functional_term_for_var
-      simp only [← equiv.left]
-      have : trg1.rule.frontier.map trg1.subs = trg1.rule.frontier.map trg2.subs := by
-        rw [List.map_inj_left]
-        exact equiv.right
-      simp only [this]
+      simp only [← equiv.left, mapped_frontier_eq_of_equiv equiv]
     | inr v_not_exis =>
       have v_front : v ∈ trg2.rule.frontier := by
         rw [← equiv.left]
-        unfold Rule.existential_vars_for_head_disjunct at v_not_exis
-        rw [List.mem_filter, not_and, decide_not, not_decide_eq_true, Decidable.not_not] at v_not_exis
-        apply v_not_exis
-        rw [FunctionFreeConjunction.mem_vars]
-        exists a
+        apply trg1.rule.mem_frontier_of_mem_head_disjunct_of_not_mem_existential_vars _ _ v_not_exis
+        rw [FunctionFreeConjunction.mem_vars]; exists a
       rw [trg2.apply_to_var_or_const_frontier_var _ _ _ v_front]
       simp only [← equiv.left] at v_front
       rw [trg1.apply_to_var_or_const_frontier_var _ _ _ v_front]
@@ -748,16 +761,7 @@ theorem equiv_of_term_mem_fresh_terms_for_head_disjunct
   rw [GroundTerm.func.injEq, SkolemFS.mk.injEq] at t_eq
   have rules_eq : trg1.rule = trg2.rule := t_eq.left.left
   constructor
-  . unfold equiv
-    constructor
-    . exact rules_eq
-    . have right := t_eq.right
-      have : trg1.rule.frontier = trg2.rule.frontier := by rw [rules_eq]
-      rw [← this] at right
-      rw [List.map_eq_map_iff] at right
-      intro v v_mem
-      apply right
-      exact v_mem
+  . exact equiv_of_rule_eq_of_mapped_frontier_equiv rules_eq t_eq.right
   . exact t_eq.left.right.left
 
 end PreTrigger


### PR DESCRIPTION
As another step towards formalizing RPC, we incorporate head choices (that had been missing before) and introduce the general overapproximation definition with a result showing that if a trigger is not obsolete with respect to such an overapproximation, then it is unblockable.
It still remains to introduce specific sets that adhere to the overapproximation definition. 